### PR TITLE
TECH-2491: Collapse map layers by default

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",
@@ -29,7 +29,6 @@
     "@loaders.gl/zip": "^3.4.14",
     "@localazy/cdn-client": "^1.5.2",
     "@mapbox/mapbox-gl-draw": "1.4.3",
-    "@next/third-parties": "latest",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-collapsible": "^1.0.3",

--- a/frontend/src/containers/map/sidebar/index.tsx
+++ b/frontend/src/containers/map/sidebar/index.tsx
@@ -103,7 +103,7 @@ const MapSidebar: FCWithMessages<MapSidebarProps> = ({ type }) => {
               <>
                 <Icon icon={LayersIcon} className="ml-0.5 h-4 w-4 pb-px" />
                 <span className="pl-3 pr-1 font-mono text-xs font-normal normal-case">
-                  {t('layers')}
+                  {t('map-layers')}
                 </span>
               </>
             )}

--- a/frontend/src/containers/map/sidebar/layers-panel/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/index.tsx
@@ -32,7 +32,7 @@ const LayersPanel: FCWithMessages = (): JSX.Element => {
   return (
     <div className="h-full overflow-auto px-4 text-xs">
       <div className="py-1">
-        <h3 className="text-xl font-extrabold">{t('layers')}</h3>
+        <h3 className="text-xl font-extrabold">{t('map-layers')}</h3>
       </div>
       <LayersGroup
         name={t('terrestrial-data')}

--- a/frontend/src/containers/map/store.ts
+++ b/frontend/src/containers/map/store.ts
@@ -9,7 +9,7 @@ import { LayerResponseDataObject } from '@/types/generated/strapi.schemas';
 import type { ModellingData } from '@/types/modelling';
 
 export const sidebarAtom = atom(true);
-export const layersAtom = atom(true);
+export const layersAtom = atom(false);
 
 // ? Map state
 export const layersInteractiveAtom = atom<LayerResponseDataObject['id'][]>([]);

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -35,7 +35,6 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: Props) => {
   );
 
   const router = useRouter();
-  const GTMID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
 
   const Layout = Component?.layout?.Component ?? ((page) => page?.children);
 
@@ -63,7 +62,6 @@ const App: React.FC<AppProps> = ({ Component, pageProps }: Props) => {
               <Analytics />
               <Layout {...layoutProps}>
                 <Component {...pageProps} />
-                <GoogleTagManager gtmId={GTMID} />
               </Layout>
             </MapProvider>
           </Hydrate>

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -181,7 +181,7 @@
     },
     "map-sidebar": {
       "close-layers": "Close layers",
-      "layers": "Layers",
+      "map-layers": "Map Layers",
       "toggle-sidebar": "Toggle sidebar"
     },
     "map-sidebar-main-panel": {
@@ -240,7 +240,7 @@
       "data-disclaimer": "Data disclaimer"
     },
     "map-sidebar-layers-panel": {
-      "layers": "Layers",
+      "map-layers": "Map Layers",
       "labels": "Labels",
       "basemap": "Basemap",
       "marine-data": "Marine Data",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1287,18 +1287,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/third-parties@npm:latest":
-  version: 15.1.7
-  resolution: "@next/third-parties@npm:15.1.7"
-  dependencies:
-    third-party-capital: 1.0.20
-  peerDependencies:
-    next: ^13.0.0 || ^14.0.0 || ^15.0.0
-    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-  checksum: de7f6d3ad0665e19aa218a2b11dd1c4c94c7fc5901f21801cbd50e15fe9d5573097cc585ea2a084fbef9afd9e5c2af9bdc9db801469c4e6e8b2565d77294a572
-  languageName: node
-  linkType: hard
-
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -12851,7 +12839,6 @@ __metadata:
     "@loaders.gl/zip": ^3.4.14
     "@localazy/cdn-client": ^1.5.2
     "@mapbox/mapbox-gl-draw": 1.4.3
-    "@next/third-parties": latest
     "@radix-ui/react-accordion": ^1.1.2
     "@radix-ui/react-checkbox": ^1.0.4
     "@radix-ui/react-collapsible": ^1.0.3
@@ -13706,13 +13693,6 @@ __metadata:
   dependencies:
     any-promise: ^1.0.0
   checksum: 84e1b804bfec49f3531215f17b4a6e50fd4397b5f7c1bccc427b9c656e1ecfb13ea79d899930184f78bc2f57285c54d9a50a590c8868f4f0cef5c1d9f898b05e
-  languageName: node
-  linkType: hard
-
-"third-party-capital@npm:1.0.20":
-  version: 1.0.20
-  resolution: "third-party-capital@npm:1.0.20"
-  checksum: ef5eae00bdb82b538b9f628a011fc294cd6f4bafdbb46d88f3d1a72e8c3b9e2cc2a547fdb62bc16bdd847e9da3dac2df676b154c64914f6c90ea15aac6ce0a6a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Collapse map layers panel by default and analytics clean up

### Overview
This PR does 3 things:
- make the map layer collapsed on initial load
- change the title of the map layers panel and expansion button from `Layers` to `Map Layers`
- Removes accidental duplication of google tag manger code


### Feature relevant tickets

[_Link to the related task manager tickets_](https://skytruth.atlassian.net/browse/TECH-2491)

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.