### PR TITLE
Style fix for map layer toggle button

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",

--- a/frontend/src/containers/map/sidebar/index.tsx
+++ b/frontend/src/containers/map/sidebar/index.tsx
@@ -102,10 +102,8 @@ const MapSidebar: FCWithMessages<MapSidebarProps> = ({ type }) => {
             {!isLayersOpen && (
               <>
                 <Icon icon={LayersIcon} className="ml-0.5 h-4 w-4 pb-px" />
-                <span className="pl-3 pr-1 font-mono text-xs font-normal normal-case whitespace-break-spaces">
-                  {/* Capas de mapa */}
-                  Couches de carte
-                  {/* {t('map-layers')} */}
+                <span className="whitespace-break-spaces pl-3 pr-1 font-mono text-xs font-normal normal-case">
+                  {t('map-layers')}
                 </span>
               </>
             )}

--- a/frontend/src/containers/map/sidebar/index.tsx
+++ b/frontend/src/containers/map/sidebar/index.tsx
@@ -102,8 +102,10 @@ const MapSidebar: FCWithMessages<MapSidebarProps> = ({ type }) => {
             {!isLayersOpen && (
               <>
                 <Icon icon={LayersIcon} className="ml-0.5 h-4 w-4 pb-px" />
-                <span className="pl-3 pr-1 font-mono text-xs font-normal normal-case">
-                  {t('map-layers')}
+                <span className="pl-3 pr-1 font-mono text-xs font-normal normal-case whitespace-break-spaces">
+                  {/* Capas de mapa */}
+                  Couches de carte
+                  {/* {t('map-layers')} */}
                 </span>
               </>
             )}


### PR DESCRIPTION
## Style fix for map layer toggle button

### Overview

This code fixes a weird text overflow that happened with the Spanish version of the map layer toggle

Current:
![Screenshot 2025-02-27 at 11 30 33 AM](https://github.com/user-attachments/assets/a22fb517-77ee-44d4-b160-f83d1259319b)

This Change
![Screenshot 2025-02-27 at 11 30 12 AM](https://github.com/user-attachments/assets/32db1e5f-1212-4695-9ebb-c52403c0dd4e)

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.