### PR TITLE
Fix undefined pagination param

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless-app-scaffold/cms",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Strapi application",
   "scripts": {
     "dev": "strapi develop",

--- a/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
+++ b/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
@@ -13,6 +13,7 @@ import {
 import Logger from '../../../utils/Logger';
 
 const PROTECTION_COVERAGE_STAT_NAMESPACE = 'api::protection-coverage-stat.protection-coverage-stat';
+const DEFAULT_PAGE_SIZE = 25;
 
 export default factories.createCoreController(PROTECTION_COVERAGE_STAT_NAMESPACE, ({ strapi }) => ({
     async find(ctx) {
@@ -69,6 +70,15 @@ export default factories.createCoreController(PROTECTION_COVERAGE_STAT_NAMESPACE
             }
             const [start, end] = getPaginationBounds(query.pagination, data.length);
             const paginatedData = data.slice(start, end);
+
+            if (!query.pagination) {
+                meta.pagination = {
+                    page: 1,
+                    pageSize: DEFAULT_PAGE_SIZE,
+                    pageCount: Math.ceil(data.length / DEFAULT_PAGE_SIZE),
+                    totalCount: data.length
+                }
+            }
             return { data: paginatedData, meta: { ...meta, updatedAt } };
         } catch (error) {
             Logger.error('Error fetching protection coverage stat data', { error });

--- a/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
+++ b/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
@@ -11,7 +11,6 @@ import {
 } from '@/types/generated/contentTypes';
 
 import Logger from '../../../utils/Logger';
-import pa from '../../pa/controllers/pa';
 
 const PROTECTION_COVERAGE_STAT_NAMESPACE = 'api::protection-coverage-stat.protection-coverage-stat';
 

--- a/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
+++ b/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
@@ -11,6 +11,7 @@ import {
 } from '@/types/generated/contentTypes';
 
 import Logger from '../../../utils/Logger';
+import pa from '../../pa/controllers/pa';
 
 const PROTECTION_COVERAGE_STAT_NAMESPACE = 'api::protection-coverage-stat.protection-coverage-stat';
 
@@ -71,7 +72,7 @@ export default factories.createCoreController(PROTECTION_COVERAGE_STAT_NAMESPACE
             const paginatedData = data.slice(start, end);
             return { data: paginatedData, meta: { ...meta, updatedAt } };
         } catch (error) {
-            Logger.error('Error fetching protection coverage stat data', error);
+            Logger.error('Error fetching protection coverage stat data', { error });
             return ctx.badRequest('Error fetching protection coverage stat data');
         }
     }
@@ -91,7 +92,7 @@ interface Pagination {
  * @param dataLength Total length of the data to be paginated
  * @returns start and end (exclusive) bounds for pagination
  */
-function getPaginationBounds(pagination: Pagination, dataLength: number): [start: number, end: number] {
+function getPaginationBounds(pagination: Pagination = {}, dataLength: number): [start: number, end: number] {
     const { start = null, limit = 25, page = 1, pageSize = 25 } = pagination;
     if (limit === -1) {
         return [start ?? 0, dataLength];


### PR DESCRIPTION
## Fix error raised when calling Protected area coverage stats with no pagination params

### Overview

This PR provides a default value for pagination parameters for an edge case when the pagination object can be passed as undefined.

### Testing instructions

Call  https://30x30-dev.skytruth.org/cms/api/protection-coverage-stats and you should get a valid response with the default 25 entries. Queries with pagination params should also still paginate and sort properly, this is easily tested on the dev progress tracker. 

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.