### PR TITLE
Hotfix: Handle sort parameter as object

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless-app-scaffold/cms",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A Strapi application",
   "scripts": {
     "dev": "strapi develop",

--- a/cms/src/utils/Logger.ts
+++ b/cms/src/utils/Logger.ts
@@ -8,7 +8,8 @@ export default class Logger {
    * @param message Human Readable message
    * @param data JSON blob of data to be logged under jsonPayload
    */
-  public static info(message: string, data: any): void {
+  public static info(message: string, data: any = {}): void {
+    data.severity = "INFO";
     Logger.parseMessage(message, data)
     Logger.log(console.log, data);
   }
@@ -18,7 +19,8 @@ export default class Logger {
    * @param message Human Readable message
    * @param data JSON blob of data to be logged under jsonPayload
    */
-  public static warn(message: string, data: any): void {
+  public static warn(message: string, data: any = {}): void {
+    data.severity = "WARNING";
     Logger.parseMessage(message, data)
     Logger.log(console.warn, data);
   }
@@ -28,7 +30,8 @@ export default class Logger {
    * @param message Human Readable message
    * @param data JSON blob of data to be logged under jsonPayload
    */
-  public static error(message: string, data: any): void {
+  public static error(message: string, data: any = {}): void {
+    data.severity = "ERROR";
     Logger.parseMessage(message, data)
     Logger.log(console.error, data);
   }
@@ -38,7 +41,7 @@ export default class Logger {
    * @param loggerFn Function to be used to log the data 
    * @param data Proccesed JSON blob of data to be logged under jsonPayload
    */
-  private static log(loggerFn: Function, data: any): void {
+  private static log(loggerFn: Function, data: any = {}): void {
     loggerFn(JSON.stringify({ data }));
   }
 
@@ -48,7 +51,7 @@ export default class Logger {
    * @param data JSON blob of data to be logged under jsonPayload
    * @returns 
    */
-  private static parseMessage(message: string, data: any): void {
+  private static parseMessage(message: string, data: any = {}): void {
     if (data.message) {
       data.message = message + ": " + data.message;
     } else {


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

This PR is a hot fix for a bug when calling the get protection coverage stats endpoint. It breaks when the sort query param is parsed as an object instead of a string.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.