### PR TITLE
Update sorting to handle array sort params

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@serverless-app-scaffold/cms",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A Strapi application",
   "scripts": {
     "dev": "strapi develop",

--- a/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
+++ b/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
@@ -158,7 +158,7 @@ function flattenSortParams(
     const flattened: Record<string, string> = {};
 
     for (const key in sort) {
-        if (Object.prototype.hasOwnProperty.call(sort, key)) {
+        if (Object.hasOwn(sort, key)) {
             const value = sort[key];
             const newKey = prefix ? `${prefix}.${key}` : key;
             if (value !== null && typeof value === 'object') {
@@ -174,9 +174,9 @@ function flattenSortParams(
 
 /**
  * * Normalizes sort parameters that might be provided as:
- * - a string, e.g. 'year:asc,environment.name:asc'
- * - a nested object, e.g. { location: { name: 'asc' } }
- * - or an array mixing both formats.
+ * a string, e.g. 'year:asc,environment.name:asc'
+ * a nested object, e.g. { location: { name: 'asc' } }
+ * or an array mixing both formats.
  * @param sortInput 
  * @Returns a flat object with keys in dot-notation.
  * @example { 'location.name': 'asc', environment: 'asc' }

--- a/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
+++ b/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
@@ -40,19 +40,7 @@ export default factories.createCoreController(PROTECTION_COVERAGE_STAT_NAMESPACE
             const { data, meta } = await super.find(ctx);
             // Update sort so null values are at the end
             if (query?.sort) {
-                let sortParams = {}
-                if (typeof query.sort === 'string') {
-                    const sortParamsArray = query.sort.split(/[,:]/);
-
-                    sortParamsArray.forEach((param, index) => {
-                        if (index % 2 === 0) {
-                            sortParams[param] = sortParamsArray[index + 1];
-                        }
-                    }
-                    )
-                } else if (typeof query.sort === 'object') {
-                    sortParams = query.sort;
-                }
+                const sortParams = normalizeSortParams(query.sort);
                 for (const sortItem in sortParams) {
                     data.sort((a, b) => {
                         const first = getValueByPath(a, sortItem);
@@ -153,4 +141,79 @@ function getValueByPath(
         }
 
     }, data);
+}
+/**
+ * Helper method to flatten deeply nested sort parameters into a sinlge level object
+ * with dot notation keys
+ * @param sort An object of variable depth containing the sort parameters
+ * @example {{ location: { name: 'asc' }, environment: 'asc'  }
+ * @param prefix the previous collapsed key
+ * @returns a flattened object with dot notation keys
+ * @example { 'location.name': 'asc', environment: 'asc' }
+ */
+function flattenSortParams(
+    sort: Record<string, any>,
+    prefix: string = ''
+): Record<string, string> {
+    const flattened: Record<string, string> = {};
+
+    for (const key in sort) {
+        if (Object.prototype.hasOwnProperty.call(sort, key)) {
+            const value = sort[key];
+            const newKey = prefix ? `${prefix}.${key}` : key;
+            if (value !== null && typeof value === 'object') {
+                Object.assign(flattened, flattenSortParams(value, newKey));
+            } else {
+                flattened[newKey] = value;
+            }
+        }
+    }
+
+    return flattened;
+}
+
+/**
+ * * Normalizes sort parameters that might be provided as:
+ * - a string, e.g. 'year:asc,environment.name:asc'
+ * - a nested object, e.g. { location: { name: 'asc' } }
+ * - or an array mixing both formats.
+ * @param sortInput 
+ * @Returns a flat object with keys in dot-notation.
+ * @example { 'location.name': 'asc', environment: 'asc' }
+ */
+function normalizeSortParams(
+    sortInput: string | Record<string, any> | Array<string | Record<string, any>>
+): Record<string, string> {
+    let sortParams: Record<string, string> = {};
+
+    if (Array.isArray(sortInput)) {
+        sortInput.forEach(item => {
+            if (typeof item === 'string') {
+                // Split by comma to separate sort pairs
+                const pairs = item.split(',');
+                pairs.forEach(pair => {
+                    const [key, order] = pair.split(':');
+                    if (key && order) {
+                        sortParams[key.trim()] = order.trim();
+                    }
+                });
+            } else if (typeof item === 'object' && item !== null) {
+                // Flatten the object and merge its keys
+                const flattened = flattenSortParams(item);
+                sortParams = { ...sortParams, ...flattened };
+            }
+        });
+    } else if (typeof sortInput === 'string') {
+        const pairs = sortInput.split(',');
+        pairs.forEach(pair => {
+            const [key, order] = pair.split(':');
+            if (key && order) {
+                sortParams[key.trim()] = order.trim();
+            }
+        });
+    } else if (typeof sortInput === 'object' && sortInput !== null) {
+        sortParams = flattenSortParams(sortInput);
+    }
+
+    return sortParams;
 }

--- a/cms/tsconfig.json
+++ b/cms/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "lib": [
+      "es2022"
+    ],
     "paths": {
       "@/*": [
         "./*"


### PR DESCRIPTION
## Update protection coverage stats to handle sort params passed as an array

### Overview

This PR further updates the handling of sort params for the protection coverage stats controller. Sort params can be passed a  string

```javascript
'location.mpaa_protection_level_stats.percentage:desc,environment.name:asc'
```
An object
```javascript
{
  location: {
    mpaa_protection_level_statspercentage: 'desc'
  },
  environment: {
    name: 'asc'
  }
{
```
or an Array with entries that could be either of the above

```javascript
[
  'location.mpaa_protection_level_stats.percentage:desc',
  {
     environment: {
      name: 'asc'
    }
  }
]

This updates the method to handle all three cases.

```

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.