### PR TITLE
TECH-2494: Update MPAA  protection level filter options

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",

--- a/frontend/src/containers/map/content/details/tables/national-highseas/hooks.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/hooks.tsx
@@ -235,11 +235,12 @@ const useFiltersOptions = () => {
              */
             if (
               mpaaProtectionLevel.attributes.slug !== 'fully-highly-protected' &&
-              mpaaProtectionLevel.attributes.slug !== 'less-protected-unknown') {
+              mpaaProtectionLevel.attributes.slug !== 'less-protected-unknown'
+            ) {
               acc.push({
                 name: mpaaProtectionLevel.attributes.name,
                 value: mpaaProtectionLevel.attributes.slug,
-              })
+              });
             }
             return acc;
           }, []),
@@ -429,73 +430,73 @@ export const useColumns = (
       },
       ...(environment === 'marine'
         ? [
-          {
-            id: 'mpaa_establishment_stage.name',
-            accessorKey: 'mpaa_establishment_stage.name',
-            header: () => (
-              <HeaderItem>
-                <FiltersButton
-                  field="mpaa_establishment_stage.slug"
-                  options={filtersOptions.mpaaEstablishmentStage}
-                  values={filters['mpaa_establishment_stage.slug'] ?? []}
-                  onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
-                />
-                {t('establishment-stage')}
-                <TooltipButton tooltip={tooltips?.establishmentStage} />
-              </HeaderItem>
-            ),
-            cell: ({ row }) => {
-              const { mpaa_establishment_stage } = row.original;
+            {
+              id: 'mpaa_establishment_stage.name',
+              accessorKey: 'mpaa_establishment_stage.name',
+              header: () => (
+                <HeaderItem>
+                  <FiltersButton
+                    field="mpaa_establishment_stage.slug"
+                    options={filtersOptions.mpaaEstablishmentStage}
+                    values={filters['mpaa_establishment_stage.slug'] ?? []}
+                    onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
+                  />
+                  {t('establishment-stage')}
+                  <TooltipButton tooltip={tooltips?.establishmentStage} />
+                </HeaderItem>
+              ),
+              cell: ({ row }) => {
+                const { mpaa_establishment_stage } = row.original;
 
-              const hasSubRowWithValue =
-                row.subRows.length > 0 &&
-                row.subRows.some((row) => !!row.original.mpaa_establishment_stage);
+                const hasSubRowWithValue =
+                  row.subRows.length > 0 &&
+                  row.subRows.some((row) => !!row.original.mpaa_establishment_stage);
 
-              let fallbackValue = t('not-assessed');
-              if (hasSubRowWithValue) {
-                fallbackValue = '−';
-              }
+                let fallbackValue = t('not-assessed');
+                if (hasSubRowWithValue) {
+                  fallbackValue = '−';
+                }
 
-              const formattedValue = mpaa_establishment_stage.name ?? fallbackValue;
-              return <>{formattedValue}</>;
+                const formattedValue = mpaa_establishment_stage.name ?? fallbackValue;
+                return <>{formattedValue}</>;
+              },
             },
-          },
-        ]
+          ]
         : []),
       ...(environment === 'marine'
         ? [
-          {
-            id: 'mpaa_protection_level.name',
-            accessorKey: 'mpaa_protection_level.name',
-            header: () => (
-              <HeaderItem>
-                <FiltersButton
-                  field="mpaa_protection_level.slug"
-                  options={filtersOptions.mpaaProtectionLevel}
-                  values={filters['mpaa_protection_level.slug'] ?? []}
-                  onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
-                />
-                {t('protection-level')}
-                <TooltipButton tooltip={tooltips?.protectionLevel} />
-              </HeaderItem>
-            ),
-            cell: ({ row }) => {
-              const { mpaa_protection_level } = row.original;
+            {
+              id: 'mpaa_protection_level.name',
+              accessorKey: 'mpaa_protection_level.name',
+              header: () => (
+                <HeaderItem>
+                  <FiltersButton
+                    field="mpaa_protection_level.slug"
+                    options={filtersOptions.mpaaProtectionLevel}
+                    values={filters['mpaa_protection_level.slug'] ?? []}
+                    onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
+                  />
+                  {t('protection-level')}
+                  <TooltipButton tooltip={tooltips?.protectionLevel} />
+                </HeaderItem>
+              ),
+              cell: ({ row }) => {
+                const { mpaa_protection_level } = row.original;
 
-              const hasSubRowWithValue =
-                row.subRows.length > 0 &&
-                row.subRows.some((row) => !!row.original.mpaa_protection_level);
+                const hasSubRowWithValue =
+                  row.subRows.length > 0 &&
+                  row.subRows.some((row) => !!row.original.mpaa_protection_level);
 
-              let fallbackValue = t('not-assessed');
-              if (hasSubRowWithValue) {
-                fallbackValue = '−';
-              }
+                let fallbackValue = t('not-assessed');
+                if (hasSubRowWithValue) {
+                  fallbackValue = '−';
+                }
 
-              const formattedValue = mpaa_protection_level.name ?? fallbackValue;
-              return <>{formattedValue}</>;
+                const formattedValue = mpaa_protection_level.name ?? fallbackValue;
+                return <>{formattedValue}</>;
+              },
             },
-          },
-        ]
+          ]
         : []),
     ];
   }, [locale, environment, t, tooltips, filters, onChangeFilters, filtersOptions]);
@@ -550,27 +551,27 @@ export const useData = (
       },
       ...(environment === 'marine'
         ? {
-          mpaa_establishment_stage: {
-            fields: ['slug', 'name', 'locale'],
-            populate: {
-              localizations: {
-                fields: ['slug', 'name', 'locale'],
+            mpaa_establishment_stage: {
+              fields: ['slug', 'name', 'locale'],
+              populate: {
+                localizations: {
+                  fields: ['slug', 'name', 'locale'],
+                },
               },
             },
-          },
-        }
+          }
         : {}),
       ...(environment === 'marine'
         ? {
-          mpaa_protection_level: {
-            fields: ['slug', 'name', 'locale'],
-            populate: {
-              localizations: {
-                fields: ['slug', 'name', 'locale'],
+            mpaa_protection_level: {
+              fields: ['slug', 'name', 'locale'],
+              populate: {
+                localizations: {
+                  fields: ['slug', 'name', 'locale'],
+                },
               },
             },
-          },
-        }
+          }
         : {}),
     }),
     [environment]
@@ -596,12 +597,12 @@ export const useData = (
     () => ({
       ...(environment
         ? {
-          environment: {
-            slug: {
-              $eq: environment,
+            environment: {
+              slug: {
+                $eq: environment,
+              },
             },
-          },
-        }
+          }
         : {}),
       location: {
         code: {
@@ -719,8 +720,8 @@ export const useData = (
             ...getData(attributes),
             ...(attributes.children.data.length > 0
               ? {
-                subRows: attributes.children.data.map(({ attributes }) => getData(attributes)),
-              }
+                  subRows: attributes.children.data.map(({ attributes }) => getData(attributes)),
+                }
               : {}),
           };
         }) ?? [],

--- a/frontend/src/containers/map/content/details/tables/national-highseas/hooks.tsx
+++ b/frontend/src/containers/map/content/details/tables/national-highseas/hooks.tsx
@@ -228,10 +228,21 @@ const useFiltersOptions = () => {
     {
       query: {
         select: ({ data }) =>
-          data.map((mpaaProtectionLevel) => ({
-            name: mpaaProtectionLevel.attributes.name,
-            value: mpaaProtectionLevel.attributes.slug,
-          })),
+          data.reduce((acc, mpaaProtectionLevel) => {
+            /**
+             * The following levels are not valid mpaa protection levels and hence don't make
+             * sense as filters. They are just used internally for aggregating protection stats
+             */
+            if (
+              mpaaProtectionLevel.attributes.slug !== 'fully-highly-protected' &&
+              mpaaProtectionLevel.attributes.slug !== 'less-protected-unknown') {
+              acc.push({
+                name: mpaaProtectionLevel.attributes.name,
+                value: mpaaProtectionLevel.attributes.slug,
+              })
+            }
+            return acc;
+          }, []),
         placeholderData: { data: [] },
       },
     }
@@ -418,73 +429,73 @@ export const useColumns = (
       },
       ...(environment === 'marine'
         ? [
-            {
-              id: 'mpaa_establishment_stage.name',
-              accessorKey: 'mpaa_establishment_stage.name',
-              header: () => (
-                <HeaderItem>
-                  <FiltersButton
-                    field="mpaa_establishment_stage.slug"
-                    options={filtersOptions.mpaaEstablishmentStage}
-                    values={filters['mpaa_establishment_stage.slug'] ?? []}
-                    onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
-                  />
-                  {t('establishment-stage')}
-                  <TooltipButton tooltip={tooltips?.establishmentStage} />
-                </HeaderItem>
-              ),
-              cell: ({ row }) => {
-                const { mpaa_establishment_stage } = row.original;
+          {
+            id: 'mpaa_establishment_stage.name',
+            accessorKey: 'mpaa_establishment_stage.name',
+            header: () => (
+              <HeaderItem>
+                <FiltersButton
+                  field="mpaa_establishment_stage.slug"
+                  options={filtersOptions.mpaaEstablishmentStage}
+                  values={filters['mpaa_establishment_stage.slug'] ?? []}
+                  onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
+                />
+                {t('establishment-stage')}
+                <TooltipButton tooltip={tooltips?.establishmentStage} />
+              </HeaderItem>
+            ),
+            cell: ({ row }) => {
+              const { mpaa_establishment_stage } = row.original;
 
-                const hasSubRowWithValue =
-                  row.subRows.length > 0 &&
-                  row.subRows.some((row) => !!row.original.mpaa_establishment_stage);
+              const hasSubRowWithValue =
+                row.subRows.length > 0 &&
+                row.subRows.some((row) => !!row.original.mpaa_establishment_stage);
 
-                let fallbackValue = t('not-assessed');
-                if (hasSubRowWithValue) {
-                  fallbackValue = '−';
-                }
+              let fallbackValue = t('not-assessed');
+              if (hasSubRowWithValue) {
+                fallbackValue = '−';
+              }
 
-                const formattedValue = mpaa_establishment_stage.name ?? fallbackValue;
-                return <>{formattedValue}</>;
-              },
+              const formattedValue = mpaa_establishment_stage.name ?? fallbackValue;
+              return <>{formattedValue}</>;
             },
-          ]
+          },
+        ]
         : []),
       ...(environment === 'marine'
         ? [
-            {
-              id: 'mpaa_protection_level.name',
-              accessorKey: 'mpaa_protection_level.name',
-              header: () => (
-                <HeaderItem>
-                  <FiltersButton
-                    field="mpaa_protection_level.slug"
-                    options={filtersOptions.mpaaProtectionLevel}
-                    values={filters['mpaa_protection_level.slug'] ?? []}
-                    onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
-                  />
-                  {t('protection-level')}
-                  <TooltipButton tooltip={tooltips?.protectionLevel} />
-                </HeaderItem>
-              ),
-              cell: ({ row }) => {
-                const { mpaa_protection_level } = row.original;
+          {
+            id: 'mpaa_protection_level.name',
+            accessorKey: 'mpaa_protection_level.name',
+            header: () => (
+              <HeaderItem>
+                <FiltersButton
+                  field="mpaa_protection_level.slug"
+                  options={filtersOptions.mpaaProtectionLevel}
+                  values={filters['mpaa_protection_level.slug'] ?? []}
+                  onChange={(field, values) => onChangeFilters({ ...filters, [field]: values })}
+                />
+                {t('protection-level')}
+                <TooltipButton tooltip={tooltips?.protectionLevel} />
+              </HeaderItem>
+            ),
+            cell: ({ row }) => {
+              const { mpaa_protection_level } = row.original;
 
-                const hasSubRowWithValue =
-                  row.subRows.length > 0 &&
-                  row.subRows.some((row) => !!row.original.mpaa_protection_level);
+              const hasSubRowWithValue =
+                row.subRows.length > 0 &&
+                row.subRows.some((row) => !!row.original.mpaa_protection_level);
 
-                let fallbackValue = t('not-assessed');
-                if (hasSubRowWithValue) {
-                  fallbackValue = '−';
-                }
+              let fallbackValue = t('not-assessed');
+              if (hasSubRowWithValue) {
+                fallbackValue = '−';
+              }
 
-                const formattedValue = mpaa_protection_level.name ?? fallbackValue;
-                return <>{formattedValue}</>;
-              },
+              const formattedValue = mpaa_protection_level.name ?? fallbackValue;
+              return <>{formattedValue}</>;
             },
-          ]
+          },
+        ]
         : []),
     ];
   }, [locale, environment, t, tooltips, filters, onChangeFilters, filtersOptions]);
@@ -539,27 +550,27 @@ export const useData = (
       },
       ...(environment === 'marine'
         ? {
-            mpaa_establishment_stage: {
-              fields: ['slug', 'name', 'locale'],
-              populate: {
-                localizations: {
-                  fields: ['slug', 'name', 'locale'],
-                },
+          mpaa_establishment_stage: {
+            fields: ['slug', 'name', 'locale'],
+            populate: {
+              localizations: {
+                fields: ['slug', 'name', 'locale'],
               },
             },
-          }
+          },
+        }
         : {}),
       ...(environment === 'marine'
         ? {
-            mpaa_protection_level: {
-              fields: ['slug', 'name', 'locale'],
-              populate: {
-                localizations: {
-                  fields: ['slug', 'name', 'locale'],
-                },
+          mpaa_protection_level: {
+            fields: ['slug', 'name', 'locale'],
+            populate: {
+              localizations: {
+                fields: ['slug', 'name', 'locale'],
               },
             },
-          }
+          },
+        }
         : {}),
     }),
     [environment]
@@ -585,12 +596,12 @@ export const useData = (
     () => ({
       ...(environment
         ? {
-            environment: {
-              slug: {
-                $eq: environment,
-              },
+          environment: {
+            slug: {
+              $eq: environment,
             },
-          }
+          },
+        }
         : {}),
       location: {
         code: {
@@ -708,8 +719,8 @@ export const useData = (
             ...getData(attributes),
             ...(attributes.children.data.length > 0
               ? {
-                  subRows: attributes.children.data.map(({ attributes }) => getData(attributes)),
-                }
+                subRows: attributes.children.data.map(({ attributes }) => getData(attributes)),
+              }
               : {}),
           };
         }) ?? [],

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
@@ -29,9 +29,6 @@ const ProtectionTypesWidget: FCWithMessages<ProtectionTypesWidgetProps> = ({ loc
         location: {
           code: location?.code || 'GLOB',
         },
-        mpaa_protection_level: {
-          slug: 'fully-highly-protected',
-        },
       },
       populate: '*',
       'pagination[limit]': -1,
@@ -59,15 +56,15 @@ const ProtectionTypesWidget: FCWithMessages<ProtectionTypesWidgetProps> = ({ loc
         select: ({ data }) =>
           data[0]
             ? {
-                info: data[0]?.attributes?.content,
-                sources: data[0]?.attributes?.data_sources?.data?.map(
-                  ({ id, attributes: { title, url } }) => ({
-                    id,
-                    title,
-                    url,
-                  })
-                ),
-              }
+              info: data[0]?.attributes?.content,
+              sources: data[0]?.attributes?.data_sources?.data?.map(
+                ({ id, attributes: { title, url } }) => ({
+                  id,
+                  title,
+                  url,
+                })
+              ),
+            }
             : undefined,
       },
     }

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
@@ -56,15 +56,15 @@ const ProtectionTypesWidget: FCWithMessages<ProtectionTypesWidgetProps> = ({ loc
         select: ({ data }) =>
           data[0]
             ? {
-              info: data[0]?.attributes?.content,
-              sources: data[0]?.attributes?.data_sources?.data?.map(
-                ({ id, attributes: { title, url } }) => ({
-                  id,
-                  title,
-                  url,
-                })
-              ),
-            }
+                info: data[0]?.attributes?.content,
+                sources: data[0]?.attributes?.data_sources?.data?.map(
+                  ({ id, attributes: { title, url } }) => ({
+                    id,
+                    title,
+                    url,
+                  })
+                ),
+              }
             : undefined,
       },
     }


### PR DESCRIPTION
## Remove invalid filter options from protection level filter in the insights table

### Overview

The protection level filter menu is populated from all protection levels in the DB. 2 of these levels are composite levels, that are currently not in use but could be used for internal metric aggregation. Either way, these two composite levels, do not correspond to any real MPA and hence don't make sense to offer as filter options. 

This PR, also removes some filtering on these unused composite levels in API calls


### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.