### PR TITLE
TECH-2888: Remove terrestrial time series

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",


### PR DESCRIPTION
## Remove Terrestrial Time series graph from map side panel

### Overview

The historic terrestrial data was calculated using a method that produces inaccurately low results. As we begin updating the data with accurate protected area numbers the time series will show false levels of improvement related to a change in data aggregation. This will be added back in when accurate historical data becomes available.

### Testing instructions

Deployed in dev:

This Change:
![Screenshot 2025-05-19 at 1 48 38 PM](https://github.com/user-attachments/assets/2325e39b-cec0-4f04-b10f-313f079ecd22)

Before:
![Screenshot 2025-05-19 at 1 48 56 PM](https://github.com/user-attachments/assets/1351811a-3735-469c-8ada-ed5eb46ffdda)

### Feature relevant tickets

[_Link to the related task manager tickets_](https://skytruth.atlassian.net/browse/TECH-2888)

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.