### PR TITLE
TECH-3067: Enable source specific total_area

### DIFF
--- a/cms/config/sync/admin-role.strapi-author.json
+++ b/cms/config/sync/admin-role.strapi-author.json
@@ -1547,7 +1547,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [
@@ -1578,7 +1579,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [
@@ -1600,7 +1602,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [

--- a/cms/config/sync/admin-role.strapi-editor.json
+++ b/cms/config/sync/admin-role.strapi-editor.json
@@ -1478,7 +1478,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1505,7 +1506,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1525,7 +1527,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],

--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -695,7 +695,8 @@
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -716,7 +717,8 @@
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -730,7 +732,8 @@
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1286,7 +1289,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1307,7 +1311,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1321,7 +1326,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1499,7 +1505,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1526,7 +1533,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1546,7 +1554,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##fishing-protection-level-stat.fishing-protection-level-stat.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##fishing-protection-level-stat.fishing-protection-level-stat.json
@@ -78,6 +78,20 @@
           "sortable": true
         }
       },
+      "total_area": {
+        "edit": {
+          "label": "total_area",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "total_area",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -162,6 +176,10 @@
           },
           {
             "name": "pct",
+            "size": 4
+          },
+          {
+            "name": "total_area",
             "size": 4
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##mpaa-protection-level-stat.mpaa-protection-level-stat.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##mpaa-protection-level-stat.mpaa-protection-level-stat.json
@@ -20,21 +20,6 @@
           "sortable": true
         }
       },
-      "location": {
-        "edit": {
-          "label": "location",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "code"
-        },
-        "list": {
-          "label": "location",
-          "searchable": true,
-          "sortable": true
-        }
-      },
       "mpaa_protection_level": {
         "edit": {
           "label": "mpaa_protection_level",
@@ -74,6 +59,35 @@
         },
         "list": {
           "label": "percentage",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "location": {
+        "edit": {
+          "label": "location",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "code"
+        },
+        "list": {
+          "label": "location",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "total_area": {
+        "edit": {
+          "label": "total_area",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "total_area",
           "searchable": true,
           "sortable": true
         }
@@ -138,6 +152,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "location",
+        "mpaa_protection_level",
+        "area"
+      ],
       "edit": [
         [
           {
@@ -158,13 +178,13 @@
             "name": "percentage",
             "size": 4
           }
+        ],
+        [
+          {
+            "name": "total_area",
+            "size": 4
+          }
         ]
-      ],
-      "list": [
-        "id",
-        "location",
-        "mpaa_protection_level",
-        "area"
       ]
     }
   },

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##protection-coverage-stat.protection-coverage-stat.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##protection-coverage-stat.protection-coverage-stat.json
@@ -162,6 +162,20 @@
           "sortable": true
         }
       },
+      "total_area": {
+        "edit": {
+          "label": "total_area",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "total_area",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -276,6 +290,12 @@
           },
           {
             "name": "protected_areas_count",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "total_area",
             "size": 4
           }
         ]

--- a/cms/config/sync/user-role.authenticated.json
+++ b/cms/config/sync/user-role.authenticated.json
@@ -85,6 +85,9 @@
       "action": "api::location.location.update"
     },
     {
+      "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.bulkUpsert"
+    },
+    {
       "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.find"
     },
     {

--- a/cms/src/api/fishing-protection-level-stat/content-types/fishing-protection-level-stat/schema.json
+++ b/cms/src/api/fishing-protection-level-stat/content-types/fishing-protection-level-stat/schema.json
@@ -38,6 +38,9 @@
     },
     "pct": {
       "type": "float"
+    },
+    "total_area": {
+      "type": "biginteger"
     }
   }
 }

--- a/cms/src/api/fishing-protection-level-stat/controllers/fishing-protection-level-stat.ts
+++ b/cms/src/api/fishing-protection-level-stat/controllers/fishing-protection-level-stat.ts
@@ -22,7 +22,7 @@ export default factories
           .getFishingProtectionLevelStatsMap();
 
         for (const stat of data) {
-          const { area, pct } = stat;
+          const { area, pct, total_area } = stat;
           const statKey = `${stat.location}-${stat.fishing_protection_level}`;
 
           // No existing record, create a new one
@@ -57,6 +57,7 @@ export default factories
                 data: {
                   area,
                   pct,
+                  total_area,
                   location: locationMap[stat.location],
                   fishing_protection_level: fishingProtectionLevelMap[stat.fishing_protection_level],
                 },
@@ -68,7 +69,7 @@ export default factories
               'api::fishing-protection-level-stat.fishing-protection-level-stat',
               statsMap[statKey],
               {
-                data: { area, pct },
+                data: { area, pct, total_area },
               }
             );
           }

--- a/cms/src/api/mpaa-protection-level-stat/content-types/mpaa-protection-level-stat/schema.json
+++ b/cms/src/api/mpaa-protection-level-stat/content-types/mpaa-protection-level-stat/schema.json
@@ -38,6 +38,9 @@
       "relation": "oneToOne",
       "target": "api::location.location",
       "mappedBy": "mpaa_protection_level_stats"
+    },
+    "total_area": {
+      "type": "biginteger"
     }
   }
 }

--- a/cms/src/api/mpaa-protection-level-stat/controllers/mpaa-protection-level-stat.ts
+++ b/cms/src/api/mpaa-protection-level-stat/controllers/mpaa-protection-level-stat.ts
@@ -22,8 +22,8 @@ export default factories
           .getStatsMap();
 
           for  (const stat of data) {
-            const { area, percentage } = stat;
-            const statKey = `${stat.location}-${stat.mpaa_protection_level}`
+            const { area, percentage, total_area } = stat;
+            const statKey = `${stat.location}-${stat.mpaa_protection_level}`;
 
             // No existing record, create a new one
             if (!statsMap[statKey]) {
@@ -55,6 +55,7 @@ export default factories
                   data: {
                     area,
                     percentage,
+                    total_area,
                     location: locationMap[stat.location],
                     mpaa_protection_level: MpaaProtectionLevelMap[stat.mpaa_protection_level],
                   },
@@ -69,6 +70,7 @@ export default factories
                   data: {
                     area,
                     percentage,
+                    total_area,
                   },
                 }
               );

--- a/cms/src/api/protection-coverage-stat/content-types/protection-coverage-stat/schema.json
+++ b/cms/src/api/protection-coverage-stat/content-types/protection-coverage-stat/schema.json
@@ -59,6 +59,10 @@
     },
     "global_contribution": {
       "type": "decimal"
+    },
+    "total_area": {
+      "type": "biginteger",
+      "required": false
     }
   }
 }

--- a/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
+++ b/cms/src/api/protection-coverage-stat/controllers/protection-coverage-stat.ts
@@ -90,8 +90,8 @@ export default factories.createCoreController(PROTECTION_COVERAGE_STAT_NAMESPACE
             }
             
             let { year } = ctx.params;
-            year = +year
-            const errors = []
+            year = +year;
+            const errors = [];
             await strapi.db.transaction(async () => {
                 let locationMap: IDMap = null;
                 let environmentMap: IDMap = null;

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -1306,6 +1306,7 @@ export interface ApiFishingProtectionLevelStatFishingProtectionLevelStat
         min: 0;
       }>;
     pct: Attribute.Float;
+    total_area: Attribute.BigInteger;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
@@ -1834,6 +1835,7 @@ export interface ApiMpaaProtectionLevelStatMpaaProtectionLevelStat
       'oneToOne',
       'api::location.location'
     >;
+    total_area: Attribute.BigInteger;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<
@@ -1967,6 +1969,7 @@ export interface ApiProtectionCoverageStatProtectionCoverageStat
     oecms: Attribute.Decimal;
     is_last_year: Attribute.Boolean & Attribute.DefaultTo<false>;
     global_contribution: Attribute.Decimal;
+    total_area: Attribute.BigInteger;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/fishing-protection/index.tsx
@@ -7,7 +7,7 @@ import Widget from '@/components/widget';
 import { FISHING_PROTECTION_CHART_COLORS } from '@/constants/fishing-protection-chart-colors';
 import { FCWithMessages } from '@/types';
 import { useGetDataInfos } from '@/types/generated/data-info';
-import { useGetLocations } from '@/types/generated/location';
+import { useGetFishingProtectionLevelStats } from '@/types/generated/fishing-protection-level-stat';
 import type { LocationGroupsDataItemAttributes } from '@/types/generated/strapi.schemas';
 
 type FishingProtectionWidgetProps = {
@@ -18,30 +18,27 @@ const FishingProtectionWidget: FCWithMessages<FishingProtectionWidgetProps> = ({
   const t = useTranslations('containers.map-sidebar-main-panel');
   const locale = useLocale();
 
-  // Get protection levels data for the location
   const {
-    data: { data: protectionLevelsData },
-    isFetching: isFetchingProtectionLevelsData,
-  } = useGetLocations(
+    data: { data: fishingProtectionLevelsData },
+    isFetching,
+  } = useGetFishingProtectionLevelStats(
     {
       filters: {
-        code: location?.code,
+        location: {
+          code: location?.code,
+        },
+        fishing_protection_level: {
+          slug: 'highly',
+        },
       },
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       populate: {
-        fishing_protection_level_stats: {
-          filters: {
-            fishing_protection_level: {
-              slug: 'highly',
-            },
-          },
-          populate: {
-            fishing_protection_level: '*',
-          },
+        fields: ['area', 'pct', 'total_area', 'updatedAt'],
+        fishing_protection_level: {
+          fields: ['slug'],
         },
       },
-      'pagination[limit]': -1,
     },
     {
       query: {
@@ -82,34 +79,30 @@ const FishingProtectionWidget: FCWithMessages<FishingProtectionWidgetProps> = ({
 
   // Parse data to display in the chart
   const widgetChartData = useMemo(() => {
-    if (!protectionLevelsData.length) return [];
-
+    if (!fishingProtectionLevelsData?.length) return [];
     const parsedProtectionLevel = (label: string, protectionLevel, stats) => {
       return {
         title: label,
-        slug: protectionLevel.slug,
-        background: FISHING_PROTECTION_CHART_COLORS[protectionLevel.slug],
-        totalArea: stats?.totalArea,
-        protectedArea: stats?.area,
-        percentage: stats?.pct,
+        slug: protectionLevel,
+        background: FISHING_PROTECTION_CHART_COLORS[protectionLevel],
+        totalArea: stats.total_area ?? location?.total_marine_area,
+        protectedArea: stats.area,
+        percentage: stats.pct,
         info: metadata?.info,
         sources: metadata?.sources,
-        updatedAt: stats?.updatedAt,
+        updatedAt: stats.updatedAt,
       };
     };
 
-    const fishingProtectionLevelStats =
-      protectionLevelsData[0]?.attributes?.fishing_protection_level_stats.data;
-
-    const parsedFishingProtectionLevelData = fishingProtectionLevelStats?.map((stats) => {
+    const parsedFishingProtectionLevelData = fishingProtectionLevelsData?.map((stats) => {
       const data = stats?.attributes;
-      data.totalArea = protectionLevelsData[0]?.attributes?.total_marine_area;
-      const protectionLevel = data?.fishing_protection_level?.data.attributes;
+      const protectionLevel = data?.fishing_protection_level?.data.attributes.slug;
+
       return parsedProtectionLevel(t('highly-protected-from-fishing'), protectionLevel, data);
     });
 
     return parsedFishingProtectionLevelData?.filter(Boolean) ?? [];
-  }, [t, protectionLevelsData, metadata]);
+  }, [t, fishingProtectionLevelsData, metadata, location]);
 
   const noData = useMemo(() => {
     if (!widgetChartData.length) {
@@ -129,7 +122,7 @@ const FishingProtectionWidget: FCWithMessages<FishingProtectionWidgetProps> = ({
       title={t('level-of-fishing-protection')}
       lastUpdated={widgetChartData[0]?.updatedAt}
       noData={noData}
-      loading={isFetchingProtectionLevelsData}
+      loading={isFetching}
     >
       {widgetChartData.map((chartData) => (
         <HorizontalBarChart

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/protection-types/index.tsx
@@ -87,6 +87,7 @@ const ProtectionTypesWidget: FCWithMessages<ProtectionTypesWidgetProps> = ({ loc
     const parseProtectionLevelStats = (protectionLevelStats) => {
       const mpaaProtectionLevel = protectionLevelStats?.mpaa_protection_level?.data?.attributes;
       const location = protectionLevelStats?.location?.data?.attributes;
+      const totalArea = protectionLevelStats?.total_area ?? location?.total_marine_area;
 
       const barColor = PROTECTION_TYPES_CHART_COLORS[mpaaProtectionLevel?.slug];
 
@@ -94,7 +95,7 @@ const ProtectionTypesWidget: FCWithMessages<ProtectionTypesWidgetProps> = ({ loc
         title: mpaaProtectionLevel?.name,
         slug: mpaaProtectionLevel?.slug,
         background: barColor,
-        totalArea: Number(location?.total_marine_area),
+        totalArea: Number(totalArea),
         protectedArea: protectionLevelStats?.area,
         percentage: protectionLevelStats?.percentage,
         info: metadata?.info,

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/terrestrial-conservation/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/terrestrial-conservation/index.tsx
@@ -46,7 +46,7 @@ const TerrestrialConservationWidget: FCWithMessages<TerrestrialConservationWidge
       'pagination[pageSize]': 1,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      fields: ['year', 'protected_area', 'updatedAt', 'coverage'],
+      fields: ['year', 'protected_area', 'updatedAt', 'coverage', 'total_area'],
       filters: {
         location: {
           code: {
@@ -75,8 +75,9 @@ const TerrestrialConservationWidget: FCWithMessages<TerrestrialConservationWidge
       year: Number(data[0].attributes.year),
       protectedArea: data[0].attributes.protected_area,
       coverage: data[0].attributes.coverage,
+      totalArea: Number(data[0]?.attributes.total_area ?? location.total_terrestrial_area),
     };
-  }, [data]);
+  }, [data, location]);
 
   const { data: metadata } = useGetDataInfos(
     {
@@ -107,22 +108,20 @@ const TerrestrialConservationWidget: FCWithMessages<TerrestrialConservationWidge
 
   const stats = useMemo(() => {
     if (!aggregatedData) return null;
-
-    const totalArea = Number(location.total_terrestrial_area);
     const { protectedArea } = aggregatedData;
-    const percentage = aggregatedData.coverage ?? (protectedArea / totalArea) * 100;
+    const percentage = aggregatedData.coverage ?? (protectedArea / aggregatedData.totalArea) * 100;
     const percentageFormatted = formatPercentage(locale, percentage, {
       displayPercentageSign: false,
     });
     const protectedAreaFormatted = formatKM(locale, protectedArea);
-    const totalAreaFormatted = formatKM(locale, totalArea);
+    const totalAreaFormatted = formatKM(locale, aggregatedData.totalArea);
 
     return {
       protectedPercentage: percentageFormatted,
       protectedArea: protectedAreaFormatted,
       totalArea: totalAreaFormatted,
     };
-  }, [locale, location, aggregatedData]);
+  }, [locale, aggregatedData]);
 
   const noData = useMemo(() => {
     if (!aggregatedData) {

--- a/frontend/src/types/generated/strapi.schemas.ts
+++ b/frontend/src/types/generated/strapi.schemas.ts
@@ -1802,6 +1802,7 @@ export interface ProtectionCoverageStat {
   oecms?: number;
   is_last_year?: boolean;
   global_contribution?: number;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: ProtectionCoverageStatCreatedBy;
@@ -2371,6 +2372,7 @@ export type ProtectionCoverageStatLocationDataAttributesProtectionCoverageStatsD
     oecms?: number;
     is_last_year?: boolean;
     global_contribution?: number;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: ProtectionCoverageStatLocationDataAttributesProtectionCoverageStatsDataItemAttributesCreatedBy;
@@ -2382,6 +2384,7 @@ export type ProtectionCoverageStatLocationDataAttributesMpaaProtectionLevelStats
   area?: number;
   percentage?: number;
   location?: ProtectionCoverageStatLocationDataAttributesMpaaProtectionLevelStatsDataAttributesLocation;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: ProtectionCoverageStatLocationDataAttributesMpaaProtectionLevelStatsDataAttributesCreatedBy;
@@ -2550,6 +2553,7 @@ export type ProtectionCoverageStatLocationDataAttributesFishingProtectionLevelSt
     fishing_protection_level?: ProtectionCoverageStatLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesFishingProtectionLevel;
     area?: number;
     pct?: number;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: ProtectionCoverageStatLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesCreatedBy;
@@ -3247,6 +3251,7 @@ export type PaChildrenDataItemAttributesLocationDataAttributesProtectionCoverage
     oecms?: number;
     is_last_year?: boolean;
     global_contribution?: number;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: PaChildrenDataItemAttributesLocationDataAttributesProtectionCoverageStatsDataItemAttributesCreatedBy;
@@ -3318,6 +3323,7 @@ export type PaChildrenDataItemAttributesLocationDataAttributesMpaaProtectionLeve
     area?: number;
     percentage?: number;
     location?: PaChildrenDataItemAttributesLocationDataAttributesMpaaProtectionLevelStatsDataAttributesLocation;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: PaChildrenDataItemAttributesLocationDataAttributesMpaaProtectionLevelStatsDataAttributesCreatedBy;
@@ -3473,6 +3479,7 @@ export type PaChildrenDataItemAttributesLocationDataAttributesFishingProtectionL
     fishing_protection_level?: PaChildrenDataItemAttributesLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesFishingProtectionLevel;
     area?: number;
     pct?: number;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: PaChildrenDataItemAttributesLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesCreatedBy;
@@ -4010,6 +4017,7 @@ export interface MpaaProtectionLevelStat {
   area: number;
   percentage?: number;
   location?: MpaaProtectionLevelStatLocation;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: MpaaProtectionLevelStatCreatedBy;
@@ -4455,6 +4463,7 @@ export type MpaaProtectionLevelStatLocationDataAttributesProtectionCoverageStats
     oecms?: number;
     is_last_year?: boolean;
     global_contribution?: number;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: MpaaProtectionLevelStatLocationDataAttributesProtectionCoverageStatsDataItemAttributesCreatedBy;
@@ -4582,6 +4591,7 @@ export type MpaaProtectionLevelStatLocationDataAttributesMpaaProtectionLevelStat
   area?: number;
   percentage?: number;
   location?: MpaaProtectionLevelStatLocationDataAttributesMpaaProtectionLevelStatsDataAttributesLocation;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: MpaaProtectionLevelStatLocationDataAttributesMpaaProtectionLevelStatsDataAttributesCreatedBy;
@@ -4664,6 +4674,7 @@ export type MpaaProtectionLevelStatLocationDataAttributesFishingProtectionLevelS
     fishing_protection_level?: MpaaProtectionLevelStatLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesFishingProtectionLevel;
     area?: number;
     pct?: number;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: MpaaProtectionLevelStatLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesCreatedBy;
@@ -6441,6 +6452,7 @@ export type LocationGroupsDataItemAttributesProtectionCoverageStatsDataItemAttri
   oecms?: number;
   is_last_year?: boolean;
   global_contribution?: number;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: LocationGroupsDataItemAttributesProtectionCoverageStatsDataItemAttributesCreatedBy;
@@ -6510,6 +6522,7 @@ export type LocationGroupsDataItemAttributesMpaaProtectionLevelStatsDataAttribut
   area?: number;
   percentage?: number;
   location?: LocationGroupsDataItemAttributesMpaaProtectionLevelStatsDataAttributesLocation;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: LocationGroupsDataItemAttributesMpaaProtectionLevelStatsDataAttributesCreatedBy;
@@ -6657,6 +6670,7 @@ export type LocationGroupsDataItemAttributesFishingProtectionLevelStatsDataItemA
   fishing_protection_level?: LocationGroupsDataItemAttributesFishingProtectionLevelStatsDataItemAttributesFishingProtectionLevel;
   area?: number;
   pct?: number;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: LocationGroupsDataItemAttributesFishingProtectionLevelStatsDataItemAttributesCreatedBy;
@@ -8230,6 +8244,7 @@ export type HabitatStatLocationDataAttributesProtectionCoverageStatsDataItemAttr
   oecms?: number;
   is_last_year?: boolean;
   global_contribution?: number;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: HabitatStatLocationDataAttributesProtectionCoverageStatsDataItemAttributesCreatedBy;
@@ -8241,6 +8256,7 @@ export type HabitatStatLocationDataAttributesMpaaProtectionLevelStatsDataAttribu
   area?: number;
   percentage?: number;
   location?: HabitatStatLocationDataAttributesMpaaProtectionLevelStatsDataAttributesLocation;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: HabitatStatLocationDataAttributesMpaaProtectionLevelStatsDataAttributesCreatedBy;
@@ -8402,6 +8418,7 @@ export type HabitatStatLocationDataAttributesFishingProtectionLevelStatsDataItem
   fishing_protection_level?: HabitatStatLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesFishingProtectionLevel;
   area?: number;
   pct?: number;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: HabitatStatLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesCreatedBy;
@@ -8982,6 +8999,7 @@ export interface FishingProtectionLevelStat {
   fishing_protection_level?: FishingProtectionLevelStatFishingProtectionLevel;
   area: number;
   pct?: number;
+  total_area?: string;
   createdAt?: string;
   updatedAt?: string;
   createdBy?: FishingProtectionLevelStatCreatedBy;
@@ -9466,6 +9484,7 @@ export type FishingProtectionLevelStatLocationDataAttributesProtectionCoverageSt
     oecms?: number;
     is_last_year?: boolean;
     global_contribution?: number;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: FishingProtectionLevelStatLocationDataAttributesProtectionCoverageStatsDataItemAttributesCreatedBy;
@@ -9642,6 +9661,7 @@ export type FishingProtectionLevelStatLocationDataAttributesMpaaProtectionLevelS
     area?: number;
     percentage?: number;
     location?: FishingProtectionLevelStatLocationDataAttributesMpaaProtectionLevelStatsDataAttributesLocation;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: FishingProtectionLevelStatLocationDataAttributesMpaaProtectionLevelStatsDataAttributesCreatedBy;
@@ -9730,6 +9750,7 @@ export type FishingProtectionLevelStatLocationDataAttributesFishingProtectionLev
     fishing_protection_level?: FishingProtectionLevelStatLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesFishingProtectionLevel;
     area?: number;
     pct?: number;
+    total_area?: string;
     createdAt?: string;
     updatedAt?: string;
     createdBy?: FishingProtectionLevelStatLocationDataAttributesFishingProtectionLevelStatsDataItemAttributesCreatedBy;
@@ -10032,6 +10053,7 @@ export type FishingProtectionLevelStatRequestData = {
   fishing_protection_level?: FishingProtectionLevelStatRequestDataFishingProtectionLevel;
   area: number;
   pct?: number;
+  total_area?: string;
 };
 
 export type FishingProtectionLevelResponseMeta = { [key: string]: any };


### PR DESCRIPTION
## Allow stats to have and display a total are specific to the source of the statistic

### Overview

Some of our data sources use different versions of GADM and EEZ data and, therefore, have different values for the total land and marine area of a country. This PR adds a `total_area` column to all of the statics tables (except habitat stats because that already existed as a calculated value). Additionally it adds some logic to allow our API upserting methods to pass the new field through and adds support to the front end to preferentially favor source specific total area (as opposed to what our database says the location area is).

Note: These columns will remain empty until we update and run our data pipelines with updates to pass this value through. For this reason the front end maintains fallback logic to use the current internal value of location total area.


### Feature relevant tickets

https://skytruth.atlassian.net/browse/TECH-3067
---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.