### PR TITLE
[TECH-3068]: Download GADM pipeline option

### DIFF
--- a/cloud_functions/data_processing/main.py
+++ b/cloud_functions/data_processing/main.py
@@ -13,6 +13,8 @@ from src.params import (
     CHUNK_SIZE,
     EEZ_PARAMS,
     EEZ_ZIPFILE_NAME,
+    GADM_URL,
+    GADM_ZIPFILE_NAME,
     HIGH_SEAS_PARAMS,
     HIGH_SEAS_ZIPFILE_NAME,
     MARINE_REGIONS_BODY,
@@ -100,6 +102,15 @@ def main(request: Request) -> tuple[str, int]:
 
             case "download_protected_planet_wdpa":
                 download_protected_planet(verbose=verbose)
+
+            case "download_gadm":
+                download_zip_to_gcs(
+                    GADM_URL,
+                    BUCKET,
+                    GADM_ZIPFILE_NAME,
+                    chunk_size=CHUNK_SIZE,
+                    verbose=verbose,
+                )
 
             case _:
                 print(f"METHOD: {method} not a valid option")

--- a/cloud_functions/data_processing/pyproject.toml
+++ b/cloud_functions/data_processing/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "data-processing"
-version = "0.1.0"
+version = "0.1.1"
 description = "Cloud function for agregating, processing, and updating data for the 30x30 Progress Tracker"
 authors = [
     {name = "SkyTruth"}

--- a/cloud_functions/data_processing/src/params.py
+++ b/cloud_functions/data_processing/src/params.py
@@ -102,4 +102,10 @@ SEAMOUNTS_FILE_NAME = "habitats/seamounts.zip"
 ARCHIVE_SEAMOUNTS_FILE_NAME = f"archive/habitats/{SEAMOUNTS_URL.split('/')[-1]}"
 
 
+# ------------------------------------------------------------
+#                         GADM
+# ------------------------------------------------------------
+GADM_URL = "https://geodata.ucdavis.edu/gadm/gadm4.1/gadm_410-levels.zip"
+GADM_ZIPFILE_NAME = "static/gadm_410-levels.zip"
+
 CHUNK_SIZE = 8192

--- a/cloud_functions/data_processing/src/utils/gcp.py
+++ b/cloud_functions/data_processing/src/utils/gcp.py
@@ -9,7 +9,10 @@ from google.api_core.retry import Retry
 from google.cloud import storage
 from tqdm import tqdm
 
+from src.utils.logger import Logger
+
 PROJECT = os.getenv("PROJECT", "")
+logger = Logger()
 
 
 class TqdmBytesIO(BytesIO):
@@ -165,42 +168,54 @@ def download_zip_to_gcs(
     # Start HTTP download stream
     if verbose:
         print(f"getting data from {url}")
-    if data is not None:
-        response = requests.post(
-            url, params=params, data=data, headers=headers, allow_redirects=True
-        )
-    else:
-        response = requests.get(url, stream=True)
-    response.raise_for_status()
 
-    total_size = int(response.headers.get("content-length", 0))
-    raw_buffer = BytesIO()
+    try:
+        if data is not None:
+            response = requests.post(
+                url, params=params, data=data, headers=headers, allow_redirects=True
+            )
+        else:
+            response = requests.get(url, stream=True)
+        response.raise_for_status()
+    except requests.HTTPError as excep:
+        logger.error({"message": "HTTP error during download", "error": str(excep)})
+        raise excep
+    except Exception as excep:
+        logger.error({"message": "Error during download", "error": str(excep)})
+        raise excep
 
-    if verbose:
-        print("streaming data into buffer")
-    for chunk in tqdm(
-        response.iter_content(chunk_size=chunk_size),
-        total=total_size // chunk_size + 1,
-        unit="B",
-        unit_scale=True,
-        desc="Downloading",
-    ):
-        raw_buffer.write(chunk)
+    try:
+        total_size = int(response.headers.get("content-length", 0))
+        raw_buffer = BytesIO()
 
-    raw_buffer.seek(0)
+        if verbose:
+            print("streaming data into buffer")
+        for chunk in tqdm(
+            response.iter_content(chunk_size=chunk_size),
+            total=total_size // chunk_size + 1,
+            unit="B",
+            unit_scale=True,
+            desc="Downloading",
+        ):
+            raw_buffer.write(chunk)
 
-    # Upload to GCS using TqdmBytesIO
-    tqdm_buffer = TqdmBytesIO(raw_buffer.read(), total_size=total_size, chunk_size=chunk_size)
-    tqdm_buffer.seek(0)
+        raw_buffer.seek(0)
 
-    storage_client = storage.Client()
-    bucket = storage_client.bucket(bucket_name)
-    blob = bucket.blob(blob_name)
+        # Upload to GCS using TqdmBytesIO
+        tqdm_buffer = TqdmBytesIO(raw_buffer.read(), total_size=total_size, chunk_size=chunk_size)
+        tqdm_buffer.seek(0)
 
-    if verbose:
-        print(f"Uploading to gs://{bucket_name}/{blob_name}")
-    blob.upload_from_file(tqdm_buffer, content_type="application/zip", rewind=True, timeout=600)
-    tqdm_buffer.close()
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+
+        if verbose:
+            print(f"Uploading to gs://{bucket_name}/{blob_name}")
+        blob.upload_from_file(tqdm_buffer, content_type="application/zip", rewind=True, timeout=600)
+        tqdm_buffer.close()
+    except Exception as excep:
+        logger.error({"message": "Error during upload to GCS", "error": str(excep)})
+        raise excep
 
 
 def upload_dataframe(

--- a/cloud_functions/data_processing/tests/fixtures/utils/util_mocks.py
+++ b/cloud_functions/data_processing/tests/fixtures/utils/util_mocks.py
@@ -1,0 +1,61 @@
+class MockBar:
+    """A mock tqdm bar that just records calls to update() and close()."""
+
+    def __init__(self, itterable=None):
+        self.updates = []
+        self.closed = False
+
+    def update(self, n):
+        self.updates.append(n)
+
+    def close(self):
+        self.closed = True
+
+
+class IterableMockBar(MockBar):
+    """
+    Wraps an existing iterable, yields its items,
+    and records update(len(item)) on each __next__.
+    """
+
+    def __init__(self, iterable, **kwargs):
+        super().__init__()
+        self._iter = iter(iterable)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        chunk = next(self._iter)
+        super().update(len(chunk) if hasattr(chunk, "__len__") else 1)
+        return chunk
+
+
+class MockBlob:
+    def __init__(self):
+        self.uploaded_data = None
+        self.kwargs = None
+
+    def upload_from_file(self, file_obj, **kwargs):
+        file_obj.seek(0)
+        self.uploaded_data = file_obj.read()
+        self.kwargs = kwargs
+
+
+class MockBucket:
+    def __init__(self, name, blob):
+        self.name = name
+        self._blob = blob
+
+    def blob(self, blob_name):
+        self.blob_name = blob_name
+        return self._blob
+
+
+class MockClient:
+    def __init__(self, bucket):
+        self._bucket = bucket
+
+    def bucket(self, name):
+        self.bucket_name = name
+        return self._bucket

--- a/cloud_functions/data_processing/tests/fixtures/utils/util_mocks.py
+++ b/cloud_functions/data_processing/tests/fixtures/utils/util_mocks.py
@@ -32,6 +32,8 @@ class IterableMockBar(MockBar):
 
 
 class MockBlob:
+    """Mock class for gcs blob"""
+
     def __init__(self):
         self.uploaded_data = None
         self.kwargs = None
@@ -43,6 +45,8 @@ class MockBlob:
 
 
 class MockBucket:
+    """Mokc class for GCS Bucket"""
+
     def __init__(self, name, blob):
         self.name = name
         self._blob = blob
@@ -53,9 +57,21 @@ class MockBucket:
 
 
 class MockClient:
+    """Mokc class for GCS client"""
+
     def __init__(self, bucket):
         self._bucket = bucket
 
     def bucket(self, name):
         self.bucket_name = name
         return self._bucket
+
+
+class MockRequest:
+    """Mock flask.Request.get_json(silent=True) behavior."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def get_json(self, silent=True):
+        return self._payload

--- a/cloud_functions/data_processing/tests/test_main.py
+++ b/cloud_functions/data_processing/tests/test_main.py
@@ -117,7 +117,7 @@ def test_download_gadm_invokes_download_zip_to_gcs(monkeypatch, capsys):
     result = main.main(req)
 
     assert result == ("OK", 200)
-    
+
     out = capsys.readouterr().out
     assert "Process complete!" in out
 

--- a/cloud_functions/data_processing/tests/test_main.py
+++ b/cloud_functions/data_processing/tests/test_main.py
@@ -1,16 +1,7 @@
 import pytest
 
 import main
-
-
-class MockRequest:
-    """Mimic flask.Request.get_json(silent=True) behavior."""
-
-    def __init__(self, payload):
-        self._payload = payload
-
-    def get_json(self, silent=True):
-        return self._payload
+from tests.fixtures.utils.util_mocks import MockRequest
 
 
 @pytest.fixture(autouse=True)

--- a/cloud_functions/data_processing/tests/test_main.py
+++ b/cloud_functions/data_processing/tests/test_main.py
@@ -1,0 +1,217 @@
+import pytest
+
+import main  # ← change this to the module where your `main` lives
+
+
+class MockRequest:
+    """Mimic flask.Request.get_json(silent=True) behavior."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def get_json(self, silent=True):
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def reset_patches(monkeypatch):
+    """
+    Ensure for each test that:
+    - download_zip_to_gcs, download_habitats, download_mpatlas,
+      download_protected_seas, download_protected_planet are patched back.
+      This just makes sure we don't acidently download data during a test
+    - verbose is set to False for quieter tests (you can override per-test).
+    """
+    # Default no-ops
+    monkeypatch.setattr(main, "download_zip_to_gcs", lambda *a, **k: None)
+    monkeypatch.setattr(main, "download_habitats", lambda **kw: None)
+    monkeypatch.setattr(main, "download_mpatlas", lambda **kw: None)
+    monkeypatch.setattr(main, "download_protected_seas", lambda **kw: None)
+    monkeypatch.setattr(main, "download_protected_planet", lambda **kw: None)
+    # Silence verbose by default
+    monkeypatch.setattr(main, "verbose", False)
+    yield
+
+
+def test_dry_run_only_prints_and_returns_ok(capsys):
+    req = MockRequest({"METHOD": "dry_run"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+
+    out = capsys.readouterr().out
+    assert "Dry Run Complete!" in out
+    assert "Process complete!" in out
+
+
+def test_download_eezs_invokes_download_zip_to_gcs(monkeypatch, capsys):
+    calls = []
+
+    def mock_download_zip_to_gcs(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(main, "download_zip_to_gcs", mock_download_zip_to_gcs)
+    monkeypatch.setattr(main, "verbose", True)
+
+    req = MockRequest({"METHOD": "download_eezs"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+    out = capsys.readouterr().out
+    # We only care it printed process complete
+    assert "Process complete!" in out
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+
+    assert args[0] is main.MARINE_REGIONS_URL
+    assert args[1] == main.BUCKET
+    assert args[2] == main.EEZ_ZIPFILE_NAME
+
+    assert kwargs["data"] == main.MARINE_REGIONS_BODY
+    assert kwargs["params"] == main.EEZ_PARAMS
+    assert kwargs["headers"] == main.MARINE_REGIONS_HEADERS
+    assert kwargs["chunk_size"] == main.CHUNK_SIZE
+    assert kwargs["verbose"] is True
+
+
+def test_download_high_seas_invokes_download_zip_to_gcs(monkeypatch, capsys):
+    calls = []
+
+    def mock_download_zip_to_gcs(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(main, "download_zip_to_gcs", mock_download_zip_to_gcs)
+    monkeypatch.setattr(main, "verbose", True)
+
+    req = MockRequest({"METHOD": "download_high_seas"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+    out = capsys.readouterr().out
+    # We only care it printed process complete
+    assert "Process complete!" in out
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+
+    assert args[0] is main.MARINE_REGIONS_URL
+    assert args[1] == main.BUCKET
+    assert args[2] == main.HIGH_SEAS_ZIPFILE_NAME
+
+    assert kwargs["data"] == main.MARINE_REGIONS_BODY
+    assert kwargs["params"] == main.HIGH_SEAS_PARAMS
+    assert kwargs["headers"] == main.MARINE_REGIONS_HEADERS
+    assert kwargs["chunk_size"] == main.CHUNK_SIZE
+    assert kwargs["verbose"] is True
+
+
+def test_download_gadm_invokes_download_zip_to_gcs(monkeypatch, capsys):
+    calls = []
+
+    def mock_download_zip_to_gcs(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(main, "download_zip_to_gcs", mock_download_zip_to_gcs)
+    monkeypatch.setattr(main, "verbose", True)
+
+    req = MockRequest({"METHOD": "download_gadm"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+    out = capsys.readouterr().out
+    # We only care it printed process complete
+    assert "Process complete!" in out
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+
+    assert args[0] is main.GADM_URL
+    assert args[1] == main.BUCKET
+    assert args[2] == main.GADM_ZIPFILE_NAME
+
+    assert kwargs["chunk_size"] == main.CHUNK_SIZE
+    assert kwargs["verbose"] is True
+
+
+def test_download_habitats_invokes_correct_function(monkeypatch):
+    called = {"count": 0}
+
+    def mock_habitats(**kwargs):
+        called["count"] += 1
+
+    monkeypatch.setattr(main, "download_habitats", mock_habitats)
+    req = MockRequest({"METHOD": "download_habitats"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+    assert called["count"] == 1
+
+
+def test_download_mpatlas_invokes_correct_function(monkeypatch):
+    called = {"count": 0}
+
+    def mock_mpatlas(**kwargs):
+        called["count"] += 1
+
+    monkeypatch.setattr(main, "download_mpatlas", mock_mpatlas)
+    req = MockRequest({"METHOD": "download_mpatlas"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+    assert called["count"] == 1
+
+
+def test_download_protected_seas_invokes_correct_function(monkeypatch):
+    called = {"count": 0}
+
+    def mock_protected_seas(**kwargs):
+        called["count"] += 1
+
+    monkeypatch.setattr(main, "download_protected_seas", mock_protected_seas)
+    req = MockRequest({"METHOD": "download_protected_seas"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+    assert called["count"] == 1
+
+
+def test_download_protected_planet_invokes_correct_function(monkeypatch):
+    called = {"count": 0}
+
+    def mock_protected_planet(**kwargs):
+        called["count"] += 1
+
+    monkeypatch.setattr(main, "download_protected_planet", mock_protected_planet)
+    req = MockRequest({"METHOD": "download_protected_planet_wdpa"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+    assert called["count"] == 1
+
+
+def test_unknown_method_prints_warning_and_returns_ok(capsys):
+    req = MockRequest({"METHOD": "something_else"})
+    result = main.main(req)
+
+    assert result == ("OK", 200)
+    out = capsys.readouterr().out
+    assert "METHOD: something_else not a valid option" in out
+    assert "Process complete!" in out
+
+
+def test_exception_in_handler_returns_500_and_logs(capsys, monkeypatch):
+    # Simulate download_mpatlas raising
+    def bad_mpatlas(**kwargs):
+        raise RuntimeError("mpatlas boom")
+
+    monkeypatch.setattr(main, "download_mpatlas", bad_mpatlas)
+
+    req = MockRequest({"METHOD": "download_mpatlas"})
+    result = main.main(req)
+
+    assert result[1] == 500
+    assert "Internal Server Error: mpatlas boom" in result[0]
+
+    out = capsys.readouterr().out
+    assert "METHOD download_mpatlas failed: mpatlas boom" in out

--- a/cloud_functions/data_processing/tests/test_main.py
+++ b/cloud_functions/data_processing/tests/test_main.py
@@ -1,6 +1,6 @@
 import pytest
 
-import main  # ← change this to the module where your `main` lives
+import main
 
 
 class MockRequest:
@@ -58,9 +58,8 @@ def test_download_eezs_invokes_download_zip_to_gcs(monkeypatch, capsys):
 
     assert result == ("OK", 200)
     out = capsys.readouterr().out
-    # We only care it printed process complete
-    assert "Process complete!" in out
 
+    assert "Process complete!" in out
     assert len(calls) == 1
     args, kwargs = calls[0]
 
@@ -89,9 +88,8 @@ def test_download_high_seas_invokes_download_zip_to_gcs(monkeypatch, capsys):
 
     assert result == ("OK", 200)
     out = capsys.readouterr().out
-    # We only care it printed process complete
-    assert "Process complete!" in out
 
+    assert "Process complete!" in out
     assert len(calls) == 1
     args, kwargs = calls[0]
 
@@ -119,8 +117,8 @@ def test_download_gadm_invokes_download_zip_to_gcs(monkeypatch, capsys):
     result = main.main(req)
 
     assert result == ("OK", 200)
+    
     out = capsys.readouterr().out
-    # We only care it printed process complete
     assert "Process complete!" in out
 
     assert len(calls) == 1

--- a/cloud_functions/data_processing/tests/utils/test_gcp.py
+++ b/cloud_functions/data_processing/tests/utils/test_gcp.py
@@ -1,4 +1,3 @@
-# test_tqdm_bytes_io.py
 import json
 
 import pytest
@@ -77,12 +76,10 @@ def test_TqdmBytesIO_read_updates_bar_and_returns_bytes():
     buffer = TqdmBytesIO(data, total_size=len(data), chunk_size=3)
     bar = buffer.tqdm_bar
 
-    # 1) Read chunk of the data
     chunk1 = buffer.read(3)
     assert chunk1 == b"abc"
     assert bar.updates == [3]
 
-    # 2) read the rest of the data
     chunk2 = buffer.read()
     assert chunk2 == b"def"
     assert bar.updates == [3, 3]
@@ -154,7 +151,6 @@ def test_download_zip_to_gcs_happy_path_GET(monkeypatch, capsys):
 
     # 3) Verify that GCS upload got the full concatenated body
     assert mock_blob.uploaded_data == body
-    # And check kwargs
     assert mock_blob.kwargs["content_type"] == "application/zip"
     assert mock_blob.kwargs["rewind"] is True
     assert mock_blob.kwargs["timeout"] == 600
@@ -246,7 +242,7 @@ def test_download_zip_to_gcsconnection_error_raised(capsys):
 
 @responses.activate
 def test_upload_exception_is_logged_and_raised(monkeypatch, capsys):
-    # Stub a successful GET
+
     url = "https://example.com/archive.zip"
     body = b"a"
     responses.add(

--- a/cloud_functions/data_processing/tests/utils/test_gcp.py
+++ b/cloud_functions/data_processing/tests/utils/test_gcp.py
@@ -242,7 +242,6 @@ def test_download_zip_to_gcsconnection_error_raised(capsys):
 
 @responses.activate
 def test_upload_exception_is_logged_and_raised(monkeypatch, capsys):
-
     url = "https://example.com/archive.zip"
     body = b"a"
     responses.add(

--- a/cloud_functions/data_processing/tests/utils/test_gcp.py
+++ b/cloud_functions/data_processing/tests/utils/test_gcp.py
@@ -1,0 +1,279 @@
+# test_tqdm_bytes_io.py
+import json
+
+import pytest
+import requests
+import responses
+
+import src.utils.gcp as gcp
+from src.utils.gcp import TqdmBytesIO, download_zip_to_gcs
+from tests.fixtures.utils.util_mocks import (
+    IterableMockBar,
+    MockBar,
+    MockBlob,
+    MockBucket,
+    MockClient,
+)
+
+
+@pytest.fixture(autouse=True)
+def patch_tqdm(monkeypatch):
+    """
+    Monkey‐patch gcp.tqdm (which was imported from `from tqdm import tqdm`)
+    so it returns our MockBar and records the init args.
+    """
+
+    def mock_tqdm(
+        iterable=None, total=None, unit=None, unit_scale=None, desc=None, leave=None, **kwargs
+    ):
+        mock_tqdm.last_call = (total, unit, unit_scale, desc, leave)
+        if iterable is not None:
+            return IterableMockBar(iterable, **kwargs)
+        else:
+            return MockBar()
+
+    monkeypatch.setattr(gcp, "tqdm", mock_tqdm)
+    return mock_tqdm
+
+
+@pytest.fixture
+def mock_logger(monkeypatch):
+    """
+    Mock the logger to avoid actual logging during tests.
+    """
+    mock_logger = type(
+        "MockLogger",
+        (),
+        {
+            "info": lambda self, msg: None,
+            "warning": lambda self, msg: None,
+            "error": lambda self, msg: None,
+        },
+    )
+    monkeypatch.setattr(gcp, "logger", mock_logger)
+    return mock_logger
+
+
+def test_TqdmBytesIO_init_creates_bar_with_correct_args(patch_tqdm):
+    """
+    Test that TqdmBytesIO initializes the tqdm bar with the correct parameters.
+    """
+    data = b"hello"
+    total_size = 5
+    chunk_size = 2
+
+    buffer = TqdmBytesIO(data, total_size=total_size, chunk_size=chunk_size)
+
+    assert patch_tqdm.last_call == (total_size, "B", True, "Uploading", True)
+    assert isinstance(buffer.tqdm_bar, MockBar)
+    assert buffer.chunk_size == chunk_size
+
+
+def test_TqdmBytesIO_read_updates_bar_and_returns_bytes():
+    """
+    Test that reading from TqdmBytesIO updates the bar and returns the correct bytes.
+    """
+    data = b"abcdef"
+    buffer = TqdmBytesIO(data, total_size=len(data), chunk_size=3)
+    bar = buffer.tqdm_bar
+
+    # 1) Read chunk of the data
+    chunk1 = buffer.read(3)
+    assert chunk1 == b"abc"
+    assert bar.updates == [3]
+
+    # 2) read the rest of the data
+    chunk2 = buffer.read()
+    assert chunk2 == b"def"
+    assert bar.updates == [3, 3]
+
+    # 3) reading past EOF yields empty and still updates by 0
+    chunk3 = buffer.read(1)
+    assert chunk3 == b""
+    assert bar.updates == [3, 3, 0]
+
+
+def test_TqdmBytesIO_close_closes_both_bar_and_bytesio():
+    """
+    Test that closing TqdmBytesIO also closes the tqdm bar.
+    """
+    data = b"test"
+    buffer = TqdmBytesIO(data, total_size=len(data), chunk_size=2)
+    bar = buffer.tqdm_bar
+
+    assert not buffer.closed
+
+    buffer.close()
+    assert bar.closed, "tqdm_bar.close() should have been called"
+    assert buffer.closed
+
+    # Once closed, any further read() should raise ValueError
+    with pytest.raises(ValueError):
+        buffer.read(1)
+
+
+@responses.activate
+def test_download_zip_to_gcs_happy_path_GET(monkeypatch, capsys):
+    """
+    Test the happy path of downloading a zip file from a URL with a GET endpoint
+    and uploading it to GCS.
+    """
+    url = "https://example.com/archive.zip"
+    bucket_name = "my-bucket"
+    blob_name = "dest/archive.zip"
+    body = b"foobarbaz"
+
+    responses.add(
+        responses.GET,
+        url,
+        body=body,
+        headers={"content-length": str(len(body))},
+        status=200,
+    )
+
+    mock_blob = MockBlob()
+    mock_bucket = MockBucket(bucket_name, mock_blob)
+    monkeypatch.setattr(
+        gcp.storage,
+        "Client",
+        lambda: MockClient(mock_bucket),
+    )
+
+    download_zip_to_gcs(url, bucket_name, blob_name, verbose=True)
+
+    # 1) Ensure the GET was made exactly once
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.method == "GET"
+    assert responses.calls[0].request.url == url
+
+    # 2) Check printed output
+    out = capsys.readouterr().out
+    assert f"getting data from {url}" in out
+    assert "streaming data into buffer" in out
+    assert f"Uploading to gs://{bucket_name}/{blob_name}" in out
+
+    # 3) Verify that GCS upload got the full concatenated body
+    assert mock_blob.uploaded_data == body
+    # And check kwargs
+    assert mock_blob.kwargs["content_type"] == "application/zip"
+    assert mock_blob.kwargs["rewind"] is True
+    assert mock_blob.kwargs["timeout"] == 600
+
+
+@responses.activate
+def test_download_zip_to_gcs_happy_path_POST(monkeypatch):
+    url = "https://api.example.com/zip"
+    bucket_name = "bucket"
+    blob_name = "file.zip"
+    data = {"foo": "bar"}
+    params = {"p": "v"}
+    headers = {"H": "h"}
+    body = b"x"
+
+    responses.add(
+        responses.POST,
+        url,
+        body=body,
+        headers={"content-length": "1"},
+        status=200,
+        match=[
+            responses.matchers.query_param_matcher(params),
+            responses.matchers.urlencoded_params_matcher(data),
+        ],
+    )
+
+    mock_blob = MockBlob()
+    mock_bucket = MockBucket(bucket_name, mock_blob)
+    monkeypatch.setattr(
+        gcp.storage,
+        "Client",
+        lambda: MockClient(mock_bucket),
+    )
+
+    download_zip_to_gcs(
+        url,
+        bucket_name,
+        blob_name,
+        data=data,
+        params=params,
+        headers=headers,
+        verbose=False,
+    )
+
+    assert len(responses.calls) == 1
+
+    req = responses.calls[0].request
+    assert req.method == "POST"
+    assert req.url.endswith("?p=v")
+    assert req.body == "foo=bar"
+    assert req.headers["H"] == "h"
+
+    assert mock_blob.uploaded_data == b"x"
+
+
+@responses.activate
+def test_download_zip_to_gcs_http_error_raised(capsys):
+    url = "https://example.com/missing.zip"
+    responses.add(responses.GET, url, status=404)
+
+    with pytest.raises(requests.HTTPError):
+        download_zip_to_gcs(url, "b", "f", verbose=False)
+
+    log = json.loads(capsys.readouterr().out)
+
+    assert "HTTP error during download" in log["message"]
+    assert log["severity"] == "ERROR"
+
+
+@responses.activate
+def test_download_zip_to_gcsconnection_error_raised(capsys):
+    url = "https://example.com/unreachable.zip"
+
+    responses.add(
+        responses.GET,
+        url,
+        body=requests.ConnectionError("no network"),
+    )
+
+    with pytest.raises(requests.ConnectionError):
+        download_zip_to_gcs(url, "b", "f", verbose=False)
+
+    log = json.loads(capsys.readouterr().out)
+
+    assert "Error during download" in log["message"]
+    assert log["severity"] == "ERROR"
+
+
+@responses.activate
+def test_upload_exception_is_logged_and_raised(monkeypatch, capsys):
+    # Stub a successful GET
+    url = "https://example.com/archive.zip"
+    body = b"a"
+    responses.add(
+        responses.GET,
+        url,
+        body=body,
+        headers={"content-length": "1"},
+        status=200,
+    )
+
+    # Patch storage so upload_from_file raises
+    class BadBlob(MockBlob):
+        def upload_from_file(self, file_obj, **kwargs):
+            raise RuntimeError("Upload Failed")
+
+    bad_blob = BadBlob()
+    mock_bucket = MockBucket("b", bad_blob)
+    monkeypatch.setattr(
+        gcp.storage,
+        "Client",
+        lambda: MockClient(mock_bucket),
+    )
+
+    with pytest.raises(RuntimeError):
+        download_zip_to_gcs(url, "b", "f", verbose=False)
+
+    log = json.loads(capsys.readouterr().out)
+
+    assert "Error during upload to GCS" in log["message"]
+    assert log["severity"] == "ERROR"

--- a/cms/config/sync/admin-role.strapi-author.json
+++ b/cms/config/sync/admin-role.strapi-author.json
@@ -1547,8 +1547,7 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution",
-          "total_area"
+          "global_contribution"
         ]
       },
       "conditions": [
@@ -1579,8 +1578,7 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution",
-          "total_area"
+          "global_contribution"
         ]
       },
       "conditions": [
@@ -1602,8 +1600,7 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution",
-          "total_area"
+          "global_contribution"
         ]
       },
       "conditions": [

--- a/cms/config/sync/admin-role.strapi-author.json
+++ b/cms/config/sync/admin-role.strapi-author.json
@@ -671,13 +671,73 @@
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {
+        "fields": [
+          "feature",
+          "description",
+          "payload",
+          "active_on",
+          "archived"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {},
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {},
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {
+        "fields": [
+          "feature",
+          "description",
+          "payload",
+          "active_on",
+          "archived"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {
+        "fields": [
+          "feature",
+          "description",
+          "payload",
+          "active_on",
+          "archived"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
       "subject": "api::fishing-protection-level-stat.fishing-protection-level-stat",
       "properties": {
         "fields": [
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [
@@ -702,7 +762,8 @@
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [
@@ -718,7 +779,8 @@
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [
@@ -1316,7 +1378,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [
@@ -1341,7 +1404,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [
@@ -1357,7 +1421,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [
@@ -1547,7 +1612,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [
@@ -1578,7 +1644,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [
@@ -1600,7 +1667,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [

--- a/cms/config/sync/admin-role.strapi-editor.json
+++ b/cms/config/sync/admin-role.strapi-editor.json
@@ -1478,8 +1478,7 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution",
-          "total_area"
+          "global_contribution"
         ]
       },
       "conditions": [],
@@ -1506,8 +1505,7 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution",
-          "total_area"
+          "global_contribution"
         ]
       },
       "conditions": [],
@@ -1527,8 +1525,7 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution",
-          "total_area"
+          "global_contribution"
         ]
       },
       "conditions": [],

--- a/cms/config/sync/admin-role.strapi-editor.json
+++ b/cms/config/sync/admin-role.strapi-editor.json
@@ -677,13 +677,73 @@
     },
     {
       "action": "plugin::content-manager.explorer.create",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {
+        "fields": [
+          "feature",
+          "description",
+          "payload",
+          "active_on",
+          "archived"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {},
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {},
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {
+        "fields": [
+          "feature",
+          "description",
+          "payload",
+          "active_on",
+          "archived"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::feature-flag.feature-flag",
+      "properties": {
+        "fields": [
+          "feature",
+          "description",
+          "payload",
+          "active_on",
+          "archived"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {}
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
       "subject": "api::fishing-protection-level-stat.fishing-protection-level-stat",
       "properties": {
         "fields": [
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -704,7 +764,8 @@
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -718,7 +779,8 @@
           "location",
           "fishing_protection_level",
           "area",
-          "pct"
+          "pct",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1271,7 +1333,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1292,7 +1355,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1306,7 +1370,8 @@
           "mpaa_protection_level",
           "area",
           "percentage",
-          "location"
+          "location",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1478,7 +1543,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1505,7 +1571,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],
@@ -1525,7 +1592,8 @@
           "pas",
           "oecms",
           "is_last_year",
-          "global_contribution"
+          "global_contribution",
+          "total_area"
         ]
       },
       "conditions": [],

--- a/cms/config/sync/user-role.authenticated.json
+++ b/cms/config/sync/user-role.authenticated.json
@@ -37,9 +37,6 @@
       "action": "api::dataset.dataset.update"
     },
     {
-      "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.bulkUpsert"
-    },
-    {
       "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.create"
     },
     {
@@ -56,9 +53,6 @@
     },
     {
       "action": "api::fishing-protection-level.fishing-protection-level.findOne"
-    },
-    {
-      "action": "api::habitat-stat.habitat-stat.bulkUpsert"
     },
     {
       "action": "api::habitat-stat.habitat-stat.find"
@@ -88,22 +82,10 @@
       "action": "api::location.location.update"
     },
     {
-      "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.bulkUpsert"
-    },
-    {
       "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.find"
     },
     {
       "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.findOne"
-    },
-    {
-      "action": "api::pa.pa.bulkInsert"
-    },
-    {
-      "action": "api::pa.pa.bulkPatch"
-    },
-    {
-      "action": "api::pa.pa.bulkUpdate"
     },
     {
       "action": "api::pa.pa.create"
@@ -119,9 +101,6 @@
     },
     {
       "action": "api::pa.pa.update"
-    },
-    {
-      "action": "api::protection-coverage-stat.protection-coverage-stat.bulkUpsert"
     },
     {
       "action": "api::protection-coverage-stat.protection-coverage-stat.find"

--- a/cms/config/sync/user-role.authenticated.json
+++ b/cms/config/sync/user-role.authenticated.json
@@ -37,6 +37,9 @@
       "action": "api::dataset.dataset.update"
     },
     {
+      "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.bulkUpsert"
+    },
+    {
       "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.create"
     },
     {
@@ -53,6 +56,9 @@
     },
     {
       "action": "api::fishing-protection-level.fishing-protection-level.findOne"
+    },
+    {
+      "action": "api::habitat-stat.habitat-stat.bulkUpsert"
     },
     {
       "action": "api::habitat-stat.habitat-stat.find"
@@ -82,10 +88,22 @@
       "action": "api::location.location.update"
     },
     {
+      "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.bulkUpsert"
+    },
+    {
       "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.find"
     },
     {
       "action": "api::mpaa-protection-level-stat.mpaa-protection-level-stat.findOne"
+    },
+    {
+      "action": "api::pa.pa.bulkInsert"
+    },
+    {
+      "action": "api::pa.pa.bulkPatch"
+    },
+    {
+      "action": "api::pa.pa.bulkUpdate"
     },
     {
       "action": "api::pa.pa.create"
@@ -101,6 +119,9 @@
     },
     {
       "action": "api::pa.pa.update"
+    },
+    {
+      "action": "api::protection-coverage-stat.protection-coverage-stat.bulkUpsert"
     },
     {
       "action": "api::protection-coverage-stat.protection-coverage-stat.find"

--- a/cms/config/sync/user-role.authenticated.json
+++ b/cms/config/sync/user-role.authenticated.json
@@ -76,6 +76,9 @@
       "action": "api::layer.layer.update"
     },
     {
+      "action": "api::location.location.create"
+    },
+    {
       "action": "api::location.location.find"
     },
     {

--- a/cms/config/sync/user-role.public.json
+++ b/cms/config/sync/user-role.public.json
@@ -55,9 +55,6 @@
       "action": "api::environment.environment.findOne"
     },
     {
-      "action": "api::feature-flag.feature-flag.find"
-    },
-    {
       "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.find"
     },
     {

--- a/cms/config/sync/user-role.public.json
+++ b/cms/config/sync/user-role.public.json
@@ -55,6 +55,9 @@
       "action": "api::environment.environment.findOne"
     },
     {
+      "action": "api::feature-flag.feature-flag.find"
+    },
+    {
       "action": "api::fishing-protection-level-stat.fishing-protection-level-stat.find"
     },
     {

--- a/cms/src/api/location/documentation/1.0.0/location.json
+++ b/cms/src/api/location/documentation/1.0.0/location.json
@@ -170,6 +170,85 @@
         }
       ],
       "operationId": "get/locations"
+    },
+    "post": {
+      "responses": {
+        "200": {
+          "description": "OK",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LocationResponse"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad Request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Error"
+              }
+            }
+          }
+        }
+      },
+      "tags": [
+        "Location"
+      ],
+      "parameters": [],
+      "operationId": "post/locations",
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/LocationRequest"
+            }
+          }
+        }
+      }
     }
   },
   "/locations/{id}": {

--- a/cms/src/api/location/routes/location.ts
+++ b/cms/src/api/location/routes/location.ts
@@ -5,5 +5,5 @@
 import { factories } from '@strapi/strapi';
 
 export default factories.createCoreRouter('api::location.location', {
-    only: ['find', 'findOne', 'update']
+    only: ['find', 'findOne', 'update', 'create']
 });

--- a/frontend/src/types/generated/location.ts
+++ b/frontend/src/types/generated/location.ts
@@ -18,8 +18,8 @@ import type {
   Error,
   GetLocationsParams,
   LocationResponse,
-  GetLocationsIdParams,
   LocationRequest,
+  GetLocationsIdParams,
 } from './strapi.schemas';
 import { API } from '../../services/api/index';
 import type { ErrorType, BodyType } from '../../services/api/index';
@@ -90,6 +90,69 @@ export const useGetLocations = <
   return query;
 };
 
+export const postLocations = (
+  locationRequest: BodyType<LocationRequest>,
+  options?: SecondParameter<typeof API>
+) => {
+  return API<LocationResponse>(
+    {
+      url: `/locations`,
+      method: 'post',
+      headers: { 'Content-Type': 'application/json' },
+      data: locationRequest,
+    },
+    options
+  );
+};
+
+export const getPostLocationsMutationOptions = <
+  TError = ErrorType<Error>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postLocations>>,
+    TError,
+    { data: BodyType<LocationRequest> },
+    TContext
+  >;
+  request?: SecondParameter<typeof API>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof postLocations>>,
+  TError,
+  { data: BodyType<LocationRequest> },
+  TContext
+> => {
+  const { mutation: mutationOptions, request: requestOptions } = options ?? {};
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof postLocations>>,
+    { data: BodyType<LocationRequest> }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return postLocations(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type PostLocationsMutationResult = NonNullable<Awaited<ReturnType<typeof postLocations>>>;
+export type PostLocationsMutationBody = BodyType<LocationRequest>;
+export type PostLocationsMutationError = ErrorType<Error>;
+
+export const usePostLocations = <TError = ErrorType<Error>, TContext = unknown>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof postLocations>>,
+    TError,
+    { data: BodyType<LocationRequest> },
+    TContext
+  >;
+  request?: SecondParameter<typeof API>;
+}) => {
+  const mutationOptions = getPostLocationsMutationOptions(options);
+
+  return useMutation(mutationOptions);
+};
 export const getLocationsId = (
   id: number,
   params?: GetLocationsIdParams,


### PR DESCRIPTION
## Adds a code path to download the GADM `.gpkg` data for country and region boundaries

### Overview

This PR primarily adds a code path to download GADM data to GCS. Additionally it adds some extra unit tests for existing functions, adds a post endpoint for locations data in the DB, updates some authenticated permissions 


### Feature relevant tickets

This PR is in partial completion, but does not close, https://skytruth.atlassian.net/browse/TECH-3068
---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.