### PR TITLE
Use only most recent habitat stats

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",

--- a/frontend/src/constants/habitat-chart-colors.ts
+++ b/frontend/src/constants/habitat-chart-colors.ts
@@ -1,11 +1,14 @@
 // The order of the keys affect the order of the habitats in the habitat widget
-export const HABITAT_CHART_COLORS = {
+export const MARINE_HABITAT_CHART_COLORS = {
   'warm-water corals': '#EC7667',
   'cold-water corals': '#3ACBF9',
   mangroves: '#DFC700',
   seagrasses: '#2DBA66',
   saltmarshes: '#6D7600',
   seamounts: '#884B02',
+};
+
+export const TERRESTRIAL_HABITAT_CHART_COLORS = {
   forest: '#01550E',
   savanna: '#FFE399',
   shrubland: '#C6FF53',

--- a/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/habitat/index.tsx
+++ b/frontend/src/containers/map/sidebar/main-panel/panels/details/widgets/habitat/index.tsx
@@ -1,8 +1,13 @@
+import { useMemo } from 'react';
+
 import { useLocale, useTranslations } from 'next-intl';
 
 import HorizontalBarChart from '@/components/charts/horizontal-bar-chart';
 import Widget from '@/components/widget';
-import { HABITAT_CHART_COLORS } from '@/constants/habitat-chart-colors';
+import {
+  MARINE_HABITAT_CHART_COLORS,
+  TERRESTRIAL_HABITAT_CHART_COLORS,
+} from '@/constants/habitat-chart-colors';
 import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
 import { FCWithMessages } from '@/types';
 import { useGetDataInfos } from '@/types/generated/data-info';
@@ -21,6 +26,15 @@ const HabitatWidget: FCWithMessages<HabitatWidgetProps> = ({ location }) => {
   const locale = useLocale();
 
   const [{ tab }] = useSyncMapContentSettings();
+
+  const [HABITAT_CHART_COLORS, total_habitats] = useMemo(() => {
+    const total =
+      tab === 'marine'
+        ? Object.keys(MARINE_HABITAT_CHART_COLORS).length
+        : Object.keys(TERRESTRIAL_HABITAT_CHART_COLORS).length;
+
+    return [{ ...MARINE_HABITAT_CHART_COLORS, ...TERRESTRIAL_HABITAT_CHART_COLORS }, total];
+  }, [tab]);
 
   const { data: habitatMetadatas } = useGetDataInfos<
     { slug: string; info: string; sources?: { id: number; title: string; url: string }[] }[]
@@ -84,7 +98,8 @@ const HabitatWidget: FCWithMessages<HabitatWidgetProps> = ({ location }) => {
           },
         },
       },
-      'pagination[limit]': -1,
+      'sort[year]': 'desc',
+      'pagination[limit]': total_habitats,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       fields: ['protected_area', 'total_area', 'updatedAt'],


### PR DESCRIPTION
### Overview

Fixes a bug that showed all habitat stats in habitat widget instead of just the current year's stats. This wasn't a problem before, because we only had one year of stats, but we are about to start adding new data

Before with new data updates
<img width="455" height="723" alt="Screenshot 2025-07-24 at 4 55 31 PM" src="https://github.com/user-attachments/assets/9473ef07-ad7e-4bb4-bd50-776f5d31b947" />

Now:
<img width="451" height="651" alt="Screenshot 2025-07-24 at 5 48 55 PM" src="https://github.com/user-attachments/assets/9bdc5e62-a01c-4d3c-896b-4024ce461584" />


---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.