### PR TITLE
Increase data processing memory + housekeeping

### DIFF
--- a/cms/src/api/pa/controllers/pa.ts
+++ b/cms/src/api/pa/controllers/pa.ts
@@ -11,13 +11,19 @@ export default factories.createCoreController('api::pa.pa', ({ strapi }) => ({
     // TODO TECH-3174: Clean up
     const { query } = ctx;
     let locationFilter = query?.filters?.location;
+    let childLocationFilters = query?.populate?.children?.filters?.location;
     const areTerritoriesActive = await strapi
         .service('api::feature-flag.feature-flag')
         .getFeaureFlag(ctx, 'are_territories_active');
 
     if (locationFilter && !areTerritoriesActive) {
-        query.filters.location = filterSovereigns({...locationFilter})
+        query.filters.location = filterSovereigns({...locationFilter});
     }
+
+    if (childLocationFilters && !areTerritoriesActive) {
+        query.populate.children.filters.location = filterSovereigns({...childLocationFilters})
+    }
+
     if (ctx.query['keep-if-children-match']) {
       // In addition to the controller's default behavior, we also want to keep the rows for which
       // there is at least one child that matches the filters. For this, we'll use the `children`
@@ -49,7 +55,7 @@ export default factories.createCoreController('api::pa.pa', ({ strapi }) => ({
         limit: -1,
       }) as { id: number; parent: { id: number } }[]).map((d) => d.parent.id);
 
-      const uniqueParentIds = [...new Set(parentIds)];
+      const uniqueParentIds = [...new Set(parentIds)];555577434
 
       // Then, we get the list of all parents that match the initial request or the ones for which
       // children match, using the list of ids `uniqueParentIds`.

--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -32,6 +32,7 @@ module "staging" {
   data_processing_timeout_seconds                    = 3600
   data_processing_available_memory                   = "16G"
   data_processing_available_cpu                      = 4
+  mapbox_user                                        = "skytruth"
   uptime_alert_email                                 = var.uptime_alert_email
   environment                                        = "staging"
   database_name                                      = "strapi"
@@ -64,6 +65,7 @@ module "production" {
   data_processing_timeout_seconds                    = 3600
   data_processing_available_memory                   = "16G"
   data_processing_available_cpu                      = 4
+  mapbox_user                                        = "skytruth"
   uptime_alert_email                                 = var.uptime_alert_email
   environment                                        = "production"
   database_name                                      = "strapi"

--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -30,6 +30,8 @@ module "staging" {
   analysis_function_max_instance_request_concurrency = 10
   analysis_function_available_memory                 = "256M"
   data_processing_timeout_seconds                    = 3600
+  data_processing_available_memory                   = "16G"
+  data_processing_available_cpu                      = 4
   uptime_alert_email                                 = var.uptime_alert_email
   environment                                        = "staging"
   database_name                                      = "strapi"
@@ -60,6 +62,8 @@ module "production" {
   analysis_function_max_instance_request_concurrency = 10
   analysis_function_available_memory                 = "256M"
   data_processing_timeout_seconds                    = 3600
+  data_processing_available_memory                   = "16G"
+  data_processing_available_cpu                      = 4
   uptime_alert_email                                 = var.uptime_alert_email
   environment                                        = "production"
   database_name                                      = "strapi"

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -305,6 +305,7 @@ resource "google_storage_bucket" "data_bucket" {
 locals {
   data_processing_cloud_function_env = {
     BUCKET              = google_storage_bucket.data_bucket.name
+    MAPBOX_USER         = var.mapbox_user
     PROJECT             = var.gcp_project_id
     STRAPI_API_URL      = local.api_lb_url
     STRAPI_USERNAME     = var.backend_write_user
@@ -319,6 +320,12 @@ locals {
     key        = "STRAPI_PASSWORD"
     project_id = var.gcp_project_id
     secret     = "${var.project_name}_strapi_write_user_password"
+    version    = "latest"
+  },
+  {
+    key        = "MAPBOX_TOKEN"
+    project_id = var.gcp_project_id
+    secret     = "mapbox_token"
     version    = "latest"
   }]
 }

--- a/infrastructure/base/modules/env/variables.tf
+++ b/infrastructure/base/modules/env/variables.tf
@@ -77,6 +77,11 @@ variable "cors_origin" {
   default     = "*"
 }
 
+variable "mapbox_user" {
+  type        = string
+  description = "Service account username for mapbox"
+}
+
 variable "uptime_alert_email" {
   type        = string
   description = "Email address to which uptime alerts should be sent"


### PR DESCRIPTION
## This PR increases the available memory of the data processing function, adds mapbox credentials to the env vars, and fixes a small bug with PAs and territories

### Overview

In addition to the terraform updates stated above this PR passes on ISO code filtering to gate territories into the PA children filters


## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.