### PR TITLE
TECH-3197: Add country multi select to boundaries popup

### DIFF
--- a/cms/config/sync/user-role.authenticated.json
+++ b/cms/config/sync/user-role.authenticated.json
@@ -103,9 +103,6 @@
       "action": "api::pa.pa.bulkPatch"
     },
     {
-      "action": "api::pa.pa.bulkUpsert"
-    },
-    {
       "action": "api::pa.pa.create"
     },
     {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",

--- a/frontend/src/components/ui/accordion.tsx
+++ b/frontend/src/components/ui/accordion.tsx
@@ -14,6 +14,14 @@ const AccordionItem = React.forwardRef<
 ));
 AccordionItem.displayName = 'AccordionItem';
 
+const AccordionHeader = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Header>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Header>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Header ref={ref} className={cn(className)} {...props} />
+));
+AccordionHeader.displayName = 'AccordionHeader';
+
 const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
@@ -41,4 +49,4 @@ const AccordionContent = React.forwardRef<
 ));
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent, AccordionHeader};

--- a/frontend/src/components/ui/accordion.tsx
+++ b/frontend/src/components/ui/accordion.tsx
@@ -49,4 +49,4 @@ const AccordionContent = React.forwardRef<
 ));
 AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent, AccordionHeader};
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent, AccordionHeader };

--- a/frontend/src/containers/map/content/map/popup/boundaries/StatCard.tsx
+++ b/frontend/src/containers/map/content/map/popup/boundaries/StatCard.tsx
@@ -1,0 +1,81 @@
+import { FC } from 'react';
+
+import { useLocale, useTranslations } from 'next-intl';
+
+import { formatKM } from '@/lib/utils/formats';
+
+import { POPUP_BUTTON_CONTENT_BY_SOURCE } from '../constants';
+
+interface StatCardProps {
+  environment: string;
+  formattedStat:
+    | {
+        location: string;
+        iso: string;
+        percentage: string;
+        protectedArea: string;
+        totalArea: number;
+      }
+    | {
+        location: string;
+        iso: string;
+        percentage: string;
+        protectedArea: string;
+        totalArea: string;
+      };
+  handleLocationSelected: (iso: string) => void;
+  // name: string;
+  // protectionCoverageStats: ProtectionCoverageStatListResponseDataItem[];
+  source: string;
+}
+
+const StatCard: FC<StatCardProps> = ({
+  environment,
+  formattedStat,
+  handleLocationSelected,
+  // name,
+  //protectionCoverageStats,
+  source,
+}) => {
+  const t = useTranslations('containers.map');
+  const locale = useLocale();
+
+  return (
+    <>
+      <div className="flex flex-col gap-2">
+        <div className="max-w-[95%] font-mono">
+          {environment === 'marine'
+            ? t('marine-conservation-coverage')
+            : t('terrestrial-conservation-coverage')}
+        </div>
+        <div className="space-x-1 font-mono tracking-tighter text-black">
+          {formattedStat.percentage !== '-' &&
+            t.rich('percentage-bold', {
+              percentage: formattedStat.percentage,
+              b1: (chunks) => <span className="text-[32px] font-bold leading-none">{chunks}</span>,
+              b2: (chunks) => <span className="text-lg">{chunks}</span>,
+            })}
+          {formattedStat.percentage === '-' && (
+            <span className="text-xl font-bold leading-none">{formattedStat.percentage}</span>
+          )}
+        </div>
+        <div className="space-x-1 font-mono font-medium text-black">
+          {t.rich('protected-area', {
+            br: () => <br />,
+            protectedArea: formattedStat.protectedArea,
+            totalArea: formatKM(locale, Number(formattedStat.totalArea)),
+          })}
+        </div>
+      </div>
+      <button
+        type="button"
+        className="mt-3 block w-full border border-black px-4 py-2.5 text-center font-mono text-xs"
+        onClick={() => handleLocationSelected(formattedStat.iso)}
+      >
+        {t(POPUP_BUTTON_CONTENT_BY_SOURCE[source?.['id']])}
+      </button>
+    </>
+  );
+};
+
+export default StatCard;

--- a/frontend/src/containers/map/content/map/popup/boundaries/StatCard.tsx
+++ b/frontend/src/containers/map/content/map/popup/boundaries/StatCard.tsx
@@ -6,26 +6,12 @@ import { formatKM } from '@/lib/utils/formats';
 
 import { POPUP_BUTTON_CONTENT_BY_SOURCE } from '../constants';
 
+import type { FormattedStat } from './hooks';
+
 interface StatCardProps {
   environment: string;
-  formattedStat:
-    | {
-        location: string;
-        iso: string;
-        percentage: string;
-        protectedArea: string;
-        totalArea: number;
-      }
-    | {
-        location: string;
-        iso: string;
-        percentage: string;
-        protectedArea: string;
-        totalArea: string;
-      };
+  formattedStat: FormattedStat;
   handleLocationSelected: (iso: string) => void;
-  // name: string;
-  // protectionCoverageStats: ProtectionCoverageStatListResponseDataItem[];
   source: string;
 }
 
@@ -33,8 +19,6 @@ const StatCard: FC<StatCardProps> = ({
   environment,
   formattedStat,
   handleLocationSelected,
-  // name,
-  //protectionCoverageStats,
   source,
 }) => {
   const t = useTranslations('containers.map');

--- a/frontend/src/containers/map/content/map/popup/boundaries/hooks.tsx
+++ b/frontend/src/containers/map/content/map/popup/boundaries/hooks.tsx
@@ -1,0 +1,121 @@
+import { useMemo } from 'react';
+
+import { sortBy } from 'lodash-es';
+import { useLocale } from 'next-intl';
+
+import { formatPercentage, formatKM } from '@/lib/utils/formats';
+import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
+import { ProtectionCoverageStatListResponseDataItem } from '@/types/generated/strapi.schemas';
+
+export type FormattedStat = {
+  location: string;
+  iso: string;
+  percentage: string;
+  protectedArea: number;
+  totalArea: number;
+};
+
+const useFormattedStats = (
+  locationCodes: string[],
+  environment: string,
+  enabled: boolean
+): [formattedStats: FormattedStat[], isFetching: boolean] => {
+  const locale = useLocale();
+
+  const DEFAULT_VALUE = '-';
+
+  const nameField = useMemo(() => {
+    let res = 'name';
+    if (locale === 'es') {
+      res = 'name_es';
+    }
+    if (locale === 'fr') {
+      res = 'name_fr';
+    }
+    return res;
+  }, [locale]);
+
+  const { data: protectionCoverageStats, isFetching } = useGetProtectionCoverageStats<
+    ProtectionCoverageStatListResponseDataItem[]
+  >(
+    {
+      locale,
+      filters: {
+        location: {
+          code: {
+            $in: locationCodes,
+          },
+        },
+        is_last_year: {
+          $eq: true,
+        },
+        environment: {
+          slug: {
+            $eq: environment,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      populate: {
+        location: {
+          fields: [nameField, 'code', 'total_marine_area', 'total_terrestrial_area'],
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      fields: ['coverage', 'protected_area'],
+      'pagination[limit]': 1,
+    },
+    {
+      query: {
+        select: ({ data }) => data,
+        enabled,
+      },
+    }
+  );
+
+  const formattedStats = useMemo(() => {
+    if (protectionCoverageStats?.length > 0) {
+      const stats = protectionCoverageStats.map((item, idx) => {
+        const iso = item?.attributes?.location?.data?.attributes?.['code'] ?? locationCodes[idx];
+        const location = item?.attributes?.location?.data.attributes?.[nameField ?? iso];
+        const coverage = item?.attributes?.coverage;
+        const percentage =
+          coverage !== null && coverage !== undefined
+            ? formatPercentage(locale, coverage, {
+                displayPercentageSign: false,
+              })
+            : DEFAULT_VALUE;
+
+        const pArea = item?.attributes?.protected_area;
+        const protectedArea =
+          pArea !== null && pArea !== undefined ? formatKM(locale, pArea) : DEFAULT_VALUE;
+
+        const tArea =
+          item?.attributes?.total_area ??
+          item?.attributes?.location?.data?.attributes?.[
+            environment === 'marine' ? 'total_marine_area' : 'total_terrestrial_area'
+          ];
+
+        const totalArea = !Number.isNaN(+tArea) ? +tArea : DEFAULT_VALUE;
+
+        return {
+          location,
+          iso,
+          percentage,
+          protectedArea,
+          totalArea,
+        };
+      });
+
+      // Sort so that territories are listed above sovereignties
+      return sortBy(stats, (stat) => locationCodes.indexOf(stat.iso));
+    }
+    return null;
+  }, [environment, locale, locationCodes, nameField, protectionCoverageStats]);
+
+  return [formattedStats, isFetching];
+};
+
+export default useFormattedStats;

--- a/frontend/src/containers/map/content/map/popup/boundaries/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/boundaries/index.tsx
@@ -18,6 +18,9 @@ import { useGetProtectionCoverageStats } from '@/types/generated/protection-cove
 import { ProtectionCoverageStat } from '@/types/generated/strapi.schemas';
 import { LayerTyped } from '@/types/layers';
 
+import {Accordion, AccordionItem, AccordionContent, AccordionTrigger, AccordionHeader} from '@/components/ui/accordion';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
 import { POPUP_BUTTON_CONTENT_BY_SOURCE, POPUP_PROPERTIES_BY_SOURCE } from '../constants';
 
 const BoundariesPopup: FCWithMessages<{ layerSlug: string }> = ({ layerSlug }) => {
@@ -216,51 +219,69 @@ const BoundariesPopup: FCWithMessages<{ layerSlug: string }> = ({ layerSlug }) =
       <h3 className="font-sans text-xl font-black">{localizedLocationName || '-'}</h3>
       {isFetching && <div className="my-4 text-center font-mono text-xl">{t('loading')}</div>}
       {!isFetching && !protectionCoverageStats && (
-        <div className="my-4 text-center font-mono text-xs">{t('no-data-available')}</div>
+        <div className="my-4 text-center font-mono">{t('no-data-available')}</div>
       )}
       {!isFetching && !!protectionCoverageStats && (
         <>
-          <div className="flex flex-col gap-2">
-            <div className="max-w-[95%] font-mono">
-              {environment === 'marine'
-                ? t('marine-conservation-coverage')
-                : t('terrestrial-conservation-coverage')}
-            </div>
-            <div className="space-x-1 font-mono tracking-tighter text-black">
-              {formattedStats.percentage !== '-' &&
-                t.rich('percentage-bold', {
-                  percentage: formattedStats.percentage,
-                  b1: (chunks) => (
-                    <span className="text-[32px] font-bold leading-none">{chunks}</span>
+      <Accordion
+        type='single'
+        collapsible
+      >
+          <AccordionItem className='divide-y' value='item-1'>
+            <AccordionHeader>
+            <AccordionTrigger className='flex text-lg group w-[100%]'>
+                {protectionCoverageStats?.location?.data?.attributes?.name}
+                <ChevronDown
+                  aria-hidden
+                  className='transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-180'
+                />
+              </AccordionTrigger>
+              </AccordionHeader>
+            <AccordionContent className='text-xs'>
+            <div className="flex flex-col gap-2">
+              <div className="max-w-[95%] font-mono">
+                {environment === 'marine'
+                  ? t('marine-conservation-coverage')
+                  : t('terrestrial-conservation-coverage')}
+              </div>
+              <div className="space-x-1 font-mono tracking-tighter text-black">
+                {formattedStats.percentage !== '-' &&
+                  t.rich('percentage-bold', {
+                    percentage: formattedStats.percentage,
+                    b1: (chunks) => (
+                      <span className="text-[32px] font-bold leading-none">{chunks}</span>
+                    ),
+                    b2: (chunks) => <span className="text-lg">{chunks}</span>,
+                  })}
+                {formattedStats.percentage === '-' && (
+                  <span className="text-xl font-bold leading-none">{formattedStats.percentage}</span>
+                )}
+              </div>
+              <div className="space-x-1 font-mono font-medium text-black">
+                {t.rich('protected-area', {
+                  br: () => <br />,
+                  protectedArea: formattedStats.protectedArea,
+                  totalArea: formatKM(
+                    locale,
+                    Number(
+                      protectionCoverageStats?.location.data.attributes[
+                        environment === 'marine' ? 'total_marine_area' : 'total_terrestrial_area'
+                      ]
+                    )
                   ),
-                  b2: (chunks) => <span className="text-lg">{chunks}</span>,
                 })}
-              {formattedStats.percentage === '-' && (
-                <span className="text-xl font-bold leading-none">{formattedStats.percentage}</span>
-              )}
+              </div>
             </div>
-            <div className="space-x-1 font-mono font-medium text-black">
-              {t.rich('protected-area', {
-                br: () => <br />,
-                protectedArea: formattedStats.protectedArea,
-                totalArea: formatKM(
-                  locale,
-                  Number(
-                    protectionCoverageStats?.location.data.attributes[
-                      environment === 'marine' ? 'total_marine_area' : 'total_terrestrial_area'
-                    ]
-                  )
-                ),
-              })}
-            </div>
-          </div>
-          <button
-            type="button"
-            className="mt-3 block w-full border border-black px-4 py-2.5 text-center font-mono text-xs"
-            onClick={handleLocationSelected}
-          >
-            {t(POPUP_BUTTON_CONTENT_BY_SOURCE[source?.['id']])}
-          </button>
+            <button
+              type="button"
+              className="mt-3 block w-full border border-black px-4 py-2.5 text-center font-mono text-xs"
+              onClick={handleLocationSelected}
+            >
+              {t(POPUP_BUTTON_CONTENT_BY_SOURCE[source?.['id']])}
+            </button>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
         </>
       )}
     </div>

--- a/frontend/src/containers/map/content/map/popup/boundaries/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/boundaries/index.tsx
@@ -6,8 +6,16 @@ import { useRouter } from 'next/router';
 
 import type { Feature } from 'geojson';
 import { useAtom, useAtomValue } from 'jotai';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 
+import {
+  Accordion,
+  AccordionItem,
+  AccordionContent,
+  AccordionTrigger,
+  AccordionHeader,
+} from '@/components/ui/accordion';
 import { PAGES } from '@/constants/pages';
 import { useMapSearchParams, useSyncMapLayers } from '@/containers/map/content/map/sync-settings';
 import { layersInteractiveIdsAtom, popupAtom } from '@/containers/map/store';
@@ -17,9 +25,6 @@ import { useGetLayers } from '@/types/generated/layer';
 import { useGetProtectionCoverageStats } from '@/types/generated/protection-coverage-stat';
 import { ProtectionCoverageStat } from '@/types/generated/strapi.schemas';
 import { LayerTyped } from '@/types/layers';
-
-import {Accordion, AccordionItem, AccordionContent, AccordionTrigger, AccordionHeader} from '@/components/ui/accordion';
-import { ChevronDown, ChevronRight } from 'lucide-react';
 
 import { POPUP_BUTTON_CONTENT_BY_SOURCE, POPUP_PROPERTIES_BY_SOURCE } from '../constants';
 
@@ -223,65 +228,66 @@ const BoundariesPopup: FCWithMessages<{ layerSlug: string }> = ({ layerSlug }) =
       )}
       {!isFetching && !!protectionCoverageStats && (
         <>
-      <Accordion
-        type='single'
-        collapsible
-      >
-          <AccordionItem className='divide-y' value='item-1'>
-            <AccordionHeader>
-            <AccordionTrigger className='flex text-lg group w-[100%]'>
-                {protectionCoverageStats?.location?.data?.attributes?.name}
-                <ChevronDown
-                  aria-hidden
-                  className='transition-transform duration-300 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-180'
-                />
-              </AccordionTrigger>
+          <Accordion type="single" collapsible>
+            <AccordionItem className="divide-y" value="item-1">
+              <AccordionHeader>
+                <AccordionTrigger className="group flex w-[100%] text-lg">
+                  {protectionCoverageStats?.location?.data?.attributes?.name}
+                  <ChevronDown
+                    aria-hidden
+                    className="ease-[cubic-bezier(0.87,_0,_0.13,_1)] transition-transform duration-300 group-data-[state=open]:rotate-180"
+                  />
+                </AccordionTrigger>
               </AccordionHeader>
-            <AccordionContent className='text-xs'>
-            <div className="flex flex-col gap-2">
-              <div className="max-w-[95%] font-mono">
-                {environment === 'marine'
-                  ? t('marine-conservation-coverage')
-                  : t('terrestrial-conservation-coverage')}
-              </div>
-              <div className="space-x-1 font-mono tracking-tighter text-black">
-                {formattedStats.percentage !== '-' &&
-                  t.rich('percentage-bold', {
-                    percentage: formattedStats.percentage,
-                    b1: (chunks) => (
-                      <span className="text-[32px] font-bold leading-none">{chunks}</span>
-                    ),
-                    b2: (chunks) => <span className="text-lg">{chunks}</span>,
-                  })}
-                {formattedStats.percentage === '-' && (
-                  <span className="text-xl font-bold leading-none">{formattedStats.percentage}</span>
-                )}
-              </div>
-              <div className="space-x-1 font-mono font-medium text-black">
-                {t.rich('protected-area', {
-                  br: () => <br />,
-                  protectedArea: formattedStats.protectedArea,
-                  totalArea: formatKM(
-                    locale,
-                    Number(
-                      protectionCoverageStats?.location.data.attributes[
-                        environment === 'marine' ? 'total_marine_area' : 'total_terrestrial_area'
-                      ]
-                    )
-                  ),
-                })}
-              </div>
-            </div>
-            <button
-              type="button"
-              className="mt-3 block w-full border border-black px-4 py-2.5 text-center font-mono text-xs"
-              onClick={handleLocationSelected}
-            >
-              {t(POPUP_BUTTON_CONTENT_BY_SOURCE[source?.['id']])}
-            </button>
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
+              <AccordionContent className="text-xs">
+                <div className="flex flex-col gap-2">
+                  <div className="max-w-[95%] font-mono">
+                    {environment === 'marine'
+                      ? t('marine-conservation-coverage')
+                      : t('terrestrial-conservation-coverage')}
+                  </div>
+                  <div className="space-x-1 font-mono tracking-tighter text-black">
+                    {formattedStats.percentage !== '-' &&
+                      t.rich('percentage-bold', {
+                        percentage: formattedStats.percentage,
+                        b1: (chunks) => (
+                          <span className="text-[32px] font-bold leading-none">{chunks}</span>
+                        ),
+                        b2: (chunks) => <span className="text-lg">{chunks}</span>,
+                      })}
+                    {formattedStats.percentage === '-' && (
+                      <span className="text-xl font-bold leading-none">
+                        {formattedStats.percentage}
+                      </span>
+                    )}
+                  </div>
+                  <div className="space-x-1 font-mono font-medium text-black">
+                    {t.rich('protected-area', {
+                      br: () => <br />,
+                      protectedArea: formattedStats.protectedArea,
+                      totalArea: formatKM(
+                        locale,
+                        Number(
+                          protectionCoverageStats?.location.data.attributes[
+                            environment === 'marine'
+                              ? 'total_marine_area'
+                              : 'total_terrestrial_area'
+                          ]
+                        )
+                      ),
+                    })}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="mt-3 block w-full border border-black px-4 py-2.5 text-center font-mono text-xs"
+                  onClick={handleLocationSelected}
+                >
+                  {t(POPUP_BUTTON_CONTENT_BY_SOURCE[source?.['id']])}
+                </button>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
         </>
       )}
     </div>

--- a/frontend/src/containers/map/content/map/popup/constants.ts
+++ b/frontend/src/containers/map/content/map/popup/constants.ts
@@ -5,7 +5,7 @@ import Wave from '@/styles/icons/wave.svg';
 export const POPUP_PROPERTIES_BY_SOURCE = {
   // TODO TECH-3174: Clean up eez-source after removing old EEZ layer from DB
   'ezz-source': {
-    id: 'ISO_SOV1',
+    ids: ['ISO_SOV1'],
     name: {
       en: 'GEONAME',
       es: 'GEONAME_ES',
@@ -14,7 +14,7 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
   },
   // TODO TECH-3174: Clean up regions-source after removing old marine regions layer from DB
   'regions-source': {
-    id: 'region_id',
+    ids: ['region_id'],
     name: {
       en: 'name',
       es: 'name_es',
@@ -23,7 +23,7 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
   },
   // TODO TECH-3174: Clean up regions-source after removing old marine regions layer from DB
   'gadm-countries': {
-    id: 'GID_0',
+    ids: ['GID_0'],
     name: {
       en: 'COUNTRY',
       es: 'name_es',
@@ -32,7 +32,7 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
   },
   // TODO TECH-3174: Clean up regions-source after removing old marine regions layer from DB
   'gadm-regions': {
-    id: 'region_id',
+    ids: ['region_id'],
     name: {
       en: 'name',
       es: 'name_es',
@@ -40,7 +40,7 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
     },
   },
   'eez-countries-source': {
-    id: 'ISO_TER1',
+    ids: ['ISO_TER1', 'ISO_TER2', 'ISO_TER3', 'ISO_SOV1', 'ISO_SOV2', 'ISO_SOV3'],
     name: {
       en: 'name',
       es: 'name_es',
@@ -48,7 +48,7 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
     },
   },
   'marine-regions-source': {
-    id: 'region_id',
+    ids: ['region_id'],
     name: {
       en: 'name',
       es: 'name_es',
@@ -56,7 +56,8 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
     },
   },
   countries: {
-    id: 'location',
+    // There's currently on sov1 and sov2 but the code allows for sov3
+    ids: ['location', 'ISO_SOV1', 'ISO_SOV2', 'ISO_SOV3'],
     name: {
       en: 'name',
       es: 'name_es',
@@ -64,7 +65,7 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
     },
   },
   'terrestrial-regions': {
-    id: 'region_id',
+    ids: ['region_id'],
     name: {
       en: 'name',
       es: 'name_es',

--- a/frontend/src/containers/map/content/map/popup/constants.ts
+++ b/frontend/src/containers/map/content/map/popup/constants.ts
@@ -2,6 +2,8 @@ import { IconProps } from '@/components/ui/icon';
 import Mountain from '@/styles/icons/mountain.svg';
 import Wave from '@/styles/icons/wave.svg';
 
+export const EEZ_SOURCE = 'eez-countries-source';
+
 export const POPUP_PROPERTIES_BY_SOURCE = {
   // TODO TECH-3174: Clean up eez-source after removing old EEZ layer from DB
   'ezz-source': {
@@ -39,7 +41,7 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
       fr: 'name_fr',
     },
   },
-  'eez-countries-source': {
+  [EEZ_SOURCE]: {
     ids: ['ISO_TER1', 'ISO_TER2', 'ISO_TER3', 'ISO_SOV1', 'ISO_SOV2', 'ISO_SOV3'],
     name: {
       en: 'name',
@@ -80,7 +82,7 @@ export const POPUP_ICON_BY_SOURCE = {
   'regions-source': Wave as IconProps['icon'], // TODO TECH-3174: Clean up
   'gadm-countries': Mountain as IconProps['icon'], // TODO TECH-3174: Clean up
   'gadm-regions': Mountain as IconProps['icon'], // TODO TECH-3174: Clean up
-  'eez-countries-source': Wave as IconProps['icon'],
+  [EEZ_SOURCE]: Wave as IconProps['icon'],
   'marine-regions-source': Wave as IconProps['icon'],
   countries: Mountain as IconProps['icon'],
   'terrestrial-regions': Mountain as IconProps['icon'],
@@ -92,7 +94,7 @@ export const POPUP_BUTTON_CONTENT_BY_SOURCE = {
   'regions-source': 'open-region-insights', // TODO TECH-3174: Clean up
   'gadm-countries': 'open-country-insights', // TODO TECH-3174: Clean up
   'terrestrial-regions': 'open-region-insights', // TODO TECH-3174: Clean up
-  'eez-countries-source': 'open-country-insights',
+  [EEZ_SOURCE]: 'open-country-insights',
   'marine-regions-source': 'open-region-insights',
   countries: 'open-country-insights',
   'gadm-regions': 'open-region-insights',

--- a/frontend/src/containers/map/content/map/popup/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/index.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Popup } from 'react-map-gl';
 
 import { useAtomValue, useSetAtom } from 'jotai';
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { useKey } from 'rooks';
 
 import Icon from '@/components/ui/icon';
@@ -23,10 +23,11 @@ import { useGetLayers } from '@/types/generated/layer';
 
 import { useSyncMapLayers } from '../sync-settings';
 
-import { POPUP_ICON_BY_SOURCE, POPUP_PROPERTIES_BY_SOURCE } from './constants';
+import { EEZ_SOURCE, POPUP_ICON_BY_SOURCE, POPUP_PROPERTIES_BY_SOURCE } from './constants';
 
 const PopupContainer: FCWithMessages = () => {
   const locale = useLocale();
+  const t = useTranslations('containers.map');
 
   const popup = useAtomValue(popupAtom);
   const layersInteractive = useAtomValue(layersInteractiveAtom);
@@ -80,6 +81,10 @@ const PopupContainer: FCWithMessages = () => {
   const hoverTooltipContent = useMemo(() => {
     const { properties, source } = popup?.features?.[0] ?? {};
 
+    const ids = new Set(['ISO_TER1', 'ISO_TER2', 'ISO_TER3']);
+    const propertiesSet = properties ? new Set(Object.keys(properties)) : new Set();
+    const isMultiClaimEEZ = source === EEZ_SOURCE && ids.intersection(propertiesSet).size >= 2;
+
     if (!properties) {
       return null;
     }
@@ -90,9 +95,12 @@ const PopupContainer: FCWithMessages = () => {
           <Icon icon={POPUP_ICON_BY_SOURCE[source]} className="mr-2 inline-block w-[14px]" />
         ) : null}
         {properties[POPUP_PROPERTIES_BY_SOURCE[source]?.name[locale]] ?? null}
+        <div className="mt-[0.25rem] text-xs">
+          {isMultiClaimEEZ ? `* ${t('eez-multi-claim')}` : null}
+        </div>
       </div>
     );
-  }, [locale, popup]);
+  }, [locale, popup, t]);
 
   const closePopup = useCallback(() => {
     setPopup({});
@@ -168,6 +176,6 @@ const PopupContainer: FCWithMessages = () => {
   );
 };
 
-PopupContainer.messages = [...PopupItem.messages];
+PopupContainer.messages = ['containers.map', ...PopupItem.messages];
 
 export default PopupContainer;

--- a/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
@@ -56,7 +56,7 @@ const ProtectedAreaPopup: FCWithMessages<{ layerSlug: string }> = ({ layerSlug }
 
   const DATA = useMemo(() => {
     const source = layerQuery?.data?.source;
-  
+
     if (source?.type === 'vector' && rendered && popup && map) {
       const point = map.project(popup.lngLat);
 

--- a/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
+++ b/frontend/src/containers/map/content/map/popup/protected-area/index.tsx
@@ -54,9 +54,9 @@ const ProtectedAreaPopup: FCWithMessages<{ layerSlug: string }> = ({ layerSlug }
     }
   );
 
-  const { source } = layerQuery.data;
-
   const DATA = useMemo(() => {
+    const source = layerQuery?.data?.source;
+  
     if (source?.type === 'vector' && rendered && popup && map) {
       const point = map.project(popup.lngLat);
 
@@ -85,7 +85,7 @@ const ProtectedAreaPopup: FCWithMessages<{ layerSlug: string }> = ({ layerSlug }
     }
 
     return DATA_REF.current;
-  }, [popup, source, layersInteractiveIds, map, rendered]);
+  }, [popup, layerQuery, layersInteractiveIds, map, rendered]);
 
   const locationQuery = useGetLocations(
     {
@@ -119,7 +119,7 @@ const ProtectedAreaPopup: FCWithMessages<{ layerSlug: string }> = ({ layerSlug }
   if (!DATA) return null;
 
   const globalCoveragePercentage =
-    (DATA.REP_M_AREA / Number(locationQuery.data?.attributes?.total_marine_area)) * 100;
+    (DATA.GIS_AREA / Number(locationQuery.data?.attributes?.total_marine_area)) * 100;
 
   const classNameByMPAType = cn({
     'text-green': DATA?.PA_DEF === '1',
@@ -151,7 +151,7 @@ const ProtectedAreaPopup: FCWithMessages<{ layerSlug: string }> = ({ layerSlug }
                 {t('area-km2', {
                   area: format({
                     locale,
-                    value: DATA?.REP_M_AREA,
+                    value: DATA?.GIS_AREA,
                     id: 'formatKM',
                     options: {
                       maximumSignificantDigits: 3,

--- a/frontend/src/containers/map/content/map/sync-settings.ts
+++ b/frontend/src/containers/map/content/map/sync-settings.ts
@@ -31,6 +31,10 @@ export const useSyncMapLayers = () => {
   return useQueryState('layers', parseAsArrayOf(parseAsString).withDefault([]));
 };
 
+export const useSyncRunAsOf = () => {
+  return useQueryState('run-as-of');
+};
+
 export const useSyncMapLayerSettings = () => {
   return useQueryState(
     'layer-settings',
@@ -47,6 +51,7 @@ export const useMapSearchParams = (): URLSearchParams => {
   const [layers] = useSyncMapLayers();
   const [layerSettings] = useSyncMapLayerSettings();
   const [contentSettings] = useSyncMapContentSettings();
+  const [runAsOf] = useSyncRunAsOf();
   const currentSearchparams = new URLSearchParams();
 
   currentSearchparams.set('layers', parseAsArrayOf(parseAsString).serialize(layers));
@@ -62,6 +67,7 @@ export const useMapSearchParams = (): URLSearchParams => {
     'content',
     parseAsJson<ContentSettings>(contentSettingsSchema.parse).serialize(contentSettings)
   );
+  currentSearchparams.set('run-as-of', runAsOf);
 
   return currentSearchparams;
 };

--- a/frontend/src/containers/map/content/map/sync-settings.ts
+++ b/frontend/src/containers/map/content/map/sync-settings.ts
@@ -31,10 +31,6 @@ export const useSyncMapLayers = () => {
   return useQueryState('layers', parseAsArrayOf(parseAsString).withDefault([]));
 };
 
-export const useSyncRunAsOf = () => {
-  return useQueryState('run-as-of');
-};
-
 export const useSyncMapLayerSettings = () => {
   return useQueryState(
     'layer-settings',
@@ -51,7 +47,6 @@ export const useMapSearchParams = (): URLSearchParams => {
   const [layers] = useSyncMapLayers();
   const [layerSettings] = useSyncMapLayerSettings();
   const [contentSettings] = useSyncMapContentSettings();
-  const [runAsOf] = useSyncRunAsOf();
   const currentSearchparams = new URLSearchParams();
 
   currentSearchparams.set('layers', parseAsArrayOf(parseAsString).serialize(layers));
@@ -67,7 +62,6 @@ export const useMapSearchParams = (): URLSearchParams => {
     'content',
     parseAsJson<ContentSettings>(contentSettingsSchema.parse).serialize(contentSettings)
   );
-  currentSearchparams.set('run-as-of', runAsOf);
 
   return currentSearchparams;
 };

--- a/frontend/translations/en.json
+++ b/frontend/translations/en.json
@@ -262,7 +262,8 @@
       "next-page": "Next page",
       "page-number": "<a>Page</a> {number}",
       "collapse-sub-rows": "Collapse sub-rows",
-      "expand-sub-rows": "Expand sub-rows"
+      "expand-sub-rows": "Expand sub-rows",
+      "eez-multi-claim": "EEZ claimed by multiple countries"
     }
   },
   "components": {


### PR DESCRIPTION
### Overview

This PR updates the hover and click popups for boundaries (country, eez, marine and terrestrial regions) so that when a location has multiple claims that is displayed to the user, this includes what sovereign rollups the location is included in.

Hover Before:
<img width="407" height="220" alt="Screenshot 2025-09-16 at 10 09 51 AM" src="https://github.com/user-attachments/assets/98842d55-2cf1-458c-ab7b-9bf3b8af8760" />

Hover After:
<img width="427" height="271" alt="Screenshot 2025-09-16 at 10 10 28 AM" src="https://github.com/user-attachments/assets/994ec93f-05fb-4434-8827-f0c2e8d4f241" />

Popup before:
<img width="358" height="420" alt="Screenshot 2025-09-16 at 10 14 07 AM" src="https://github.com/user-attachments/assets/946e33c4-53e8-4bf0-aca8-a4fb15aed68a" />

Popup After
<img width="410" height="354" alt="Screenshot 2025-09-16 at 10 11 42 AM" src="https://github.com/user-attachments/assets/2220c059-e34e-4d51-bb57-c7c3be44746b" />

<img width="419" height="511" alt="Screenshot 2025-09-16 at 10 13 35 AM" src="https://github.com/user-attachments/assets/2d85c26d-84d5-4073-902b-0c467030114e" />

### Testing instructions

This feature works off the updated data for territories, which is still behind a feature flag. A `run-as-of` date of after 10/01/2025 must be set to view it

### Feature relevant tickets

[TECH-3197](https://skytruth.atlassian.net/browse/TECH-3197)

---
