### PR TITLE
TECH-3062: Clean up query params

### DIFF
--- a/cms/config/sync/user-role.authenticated.json
+++ b/cms/config/sync/user-role.authenticated.json
@@ -103,6 +103,9 @@
       "action": "api::pa.pa.bulkPatch"
     },
     {
+      "action": "api::pa.pa.bulkUpsert"
+    },
+    {
       "action": "api::pa.pa.create"
     },
     {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",

--- a/frontend/src/containers/map/content/map/layer-manager/index.tsx
+++ b/frontend/src/containers/map/content/map/layer-manager/index.tsx
@@ -20,7 +20,7 @@ const LayerManager = ({}: { cursor: CustomMapProps['cursor'] }) => {
 
   const getSettings = useCallback(
     (slug: string) => ({
-      ...(layersSettings[slug] ?? { opacity: 1, visibility: true, expand: true }),
+      ...(layersSettings[slug] ?? { opacity: 1, visibility: true }),
       zoom,
     }),
     [layersSettings, zoom]

--- a/frontend/src/containers/map/content/map/sync-settings.ts
+++ b/frontend/src/containers/map/content/map/sync-settings.ts
@@ -15,11 +15,6 @@ const mapSettingsSchema = z.object({
 
 type MapSettings = z.infer<typeof mapSettingsSchema>;
 
-// const DEFAULT_SYNC_MAP_SETTINGS: MapSettings = {
-//   bbox: null,
-//   labels: true,
-// };
-
 export const useSyncMapSettings = () => {
   return useQueryState(
     'settings',
@@ -30,6 +25,10 @@ export const useSyncMapSettings = () => {
 export const useSyncMapLayers = () => {
   return useQueryState('layers', parseAsArrayOf(parseAsString).withDefault([]));
 };
+
+const useSyncRunAsOf = () => {
+  return useQueryState('run-as-of', {defaultValue: null});
+}
 
 export const useSyncMapLayerSettings = () => {
   return useQueryState(
@@ -47,6 +46,7 @@ export const useMapSearchParams = (): URLSearchParams => {
   const [layers] = useSyncMapLayers();
   const [layerSettings] = useSyncMapLayerSettings();
   const [contentSettings] = useSyncMapContentSettings();
+  const [runAsOf] = useSyncRunAsOf();
   const currentSearchparams = new URLSearchParams();
 
   if (layers.length) {

--- a/frontend/src/containers/map/content/map/sync-settings.ts
+++ b/frontend/src/containers/map/content/map/sync-settings.ts
@@ -15,15 +15,15 @@ const mapSettingsSchema = z.object({
 
 type MapSettings = z.infer<typeof mapSettingsSchema>;
 
-const DEFAULT_SYNC_MAP_SETTINGS: MapSettings = {
-  bbox: null,
-  labels: true,
-};
+// const DEFAULT_SYNC_MAP_SETTINGS: MapSettings = {
+//   bbox: null,
+//   labels: true,
+// };
 
 export const useSyncMapSettings = () => {
   return useQueryState(
     'settings',
-    parseAsJson<MapSettings>(mapSettingsSchema.parse).withDefault(DEFAULT_SYNC_MAP_SETTINGS)
+    parseAsJson<MapSettings>(mapSettingsSchema.parse).withDefault({})
   );
 };
 
@@ -54,20 +54,32 @@ export const useMapSearchParams = (): URLSearchParams => {
   const [runAsOf] = useSyncRunAsOf();
   const currentSearchparams = new URLSearchParams();
 
-  currentSearchparams.set('layers', parseAsArrayOf(parseAsString).serialize(layers));
-  currentSearchparams.set(
-    'settings',
-    parseAsJson<MapSettings>(mapSettingsSchema.parse).serialize(settings)
-  );
-  currentSearchparams.set(
-    'layer-settings',
-    parseAsJson<LayerSettings>(layerSettingsSchema.parse).serialize(layerSettings)
-  );
-  currentSearchparams.set(
-    'content',
-    parseAsJson<ContentSettings>(contentSettingsSchema.parse).serialize(contentSettings)
-  );
-  currentSearchparams.set('run-as-of', runAsOf);
+  if (layers.length) {
+    currentSearchparams.set('layers', parseAsArrayOf(parseAsString).serialize(layers));
+  }
+
+  if (Object.keys(settings).length) {
+    currentSearchparams.set(
+      'settings',
+      parseAsJson<MapSettings>(mapSettingsSchema.parse).serialize(settings)
+    );
+  }
+
+  if (Object.keys(layerSettings).length) {
+    currentSearchparams.set(
+      'layer-settings',
+      parseAsJson<LayerSettings>(layerSettingsSchema.parse).serialize(layerSettings)
+    );
+  }
+
+  if (Object.keys(contentSettings).length) {
+    currentSearchparams.set(
+      'content',
+      parseAsJson<ContentSettings>(contentSettingsSchema.parse).serialize(contentSettings)
+    );
+  }
+
+  if (runAsOf) currentSearchparams.set('run-as-of', runAsOf);
 
   return currentSearchparams;
 };

--- a/frontend/src/containers/map/content/map/sync-settings.ts
+++ b/frontend/src/containers/map/content/map/sync-settings.ts
@@ -27,8 +27,8 @@ export const useSyncMapLayers = () => {
 };
 
 const useSyncRunAsOf = () => {
-  return useQueryState('run-as-of', {defaultValue: null});
-}
+  return useQueryState('run-as-of', { defaultValue: null });
+};
 
 export const useSyncMapLayerSettings = () => {
   return useQueryState(

--- a/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
@@ -7,9 +7,7 @@ import TooltipButton from '@/components/tooltip-button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import {
-  useSyncMapLayers,
-} from '@/containers/map/content/map/sync-settings';
+import { useSyncMapLayers } from '@/containers/map/content/map/sync-settings';
 import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
 import { cn } from '@/lib/classnames';
 import { FCWithMessages } from '@/types';
@@ -73,7 +71,6 @@ const LayersGroup: FCWithMessages<LayersGroupProps> = ({
           ? [...activeLayers, layerSlug]
           : activeLayers.filter((activeSlug) => activeSlug !== layerSlug)
       );
-
     },
     [activeLayers, setMapLayers]
   );

--- a/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/layers-group/index.tsx
@@ -9,7 +9,6 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import {
   useSyncMapLayers,
-  useSyncMapLayerSettings,
 } from '@/containers/map/content/map/sync-settings';
 import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
 import { cn } from '@/lib/classnames';
@@ -52,7 +51,6 @@ const LayersGroup: FCWithMessages<LayersGroupProps> = ({
   const t = useTranslations('containers.map-sidebar-layers-panel');
 
   const [activeLayers, setMapLayers] = useSyncMapLayers();
-  const [layerSettings, setLayerSettings] = useSyncMapLayerSettings();
   const [{ tab }] = useSyncMapContentSettings();
 
   const datasetsLayersIds = useMemo(() => {
@@ -76,27 +74,8 @@ const LayersGroup: FCWithMessages<LayersGroupProps> = ({
           : activeLayers.filter((activeSlug) => activeSlug !== layerSlug)
       );
 
-      // If we don't have layerSettings entries, the view is in its default state; we wish to
-      // show all legend accordion items expanded by default.
-      const initialSettings = (() => {
-        const layerSettingsKeys = Object.keys(layerSettings);
-        if (layerSettingsKeys.length) return {};
-        return Object.assign(
-          {},
-          ...activeLayers.map((layerSlug) => ({ [layerSlug]: { expanded: true } }))
-        );
-      })();
-
-      setLayerSettings((prev) => ({
-        ...initialSettings,
-        ...prev,
-        [layerSlug]: {
-          ...prev[layerSlug],
-          expanded: true,
-        },
-      }));
     },
-    [activeLayers, layerSettings, setLayerSettings, setMapLayers]
+    [activeLayers, setMapLayers]
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Overview

Cleans up unused query params to try to reduce query param bloat, it also persists the run-as-of param if it's present.
More could be done here, there are layer specific query params for opacity and visibility but shorting those to `v` and `o` would require updating a bunch of config json blobs in the layer stable in the DB (downside of the cms). So I'm choosing to leave that as extra credit if we find out that we need more clean up in the url.

### Feature relevant tickets

[TECH-3062](https://skytruth.atlassian.net/browse/TECH-3062)