### PR TITLE
Hide landing page in prep for new website

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skytruth-30x30-frontend",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "scripts": {
     "dev": "yarn types && next dev",

--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -133,22 +133,35 @@ const Header: FCWithMessages<HeaderProps> = ({ theme, hideLogo = false }) => {
         aria-label={t('global')}
       >
         <span className="flex">
-          {!hideLogo && (
-            <Link
-              href={{
-                pathname: '/',
-                query: runAsOf ? { 'run-as-of': runAsOf } : '',
-              }}
-              className="-my-1.5 inline-block ring-offset-black transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2"
-            >
-              <Image
-                src="/images/skytruth-30-30-logo.svg"
-                alt="SkyTruth 30x30"
-                width={25}
-                height={25}
-              />
-            </Link>
-          )}
+          {!hideLogo &&
+            (hideInfoPages ? (
+              <a
+                href="https://www.skytruth.org/30x30"
+                className="-my-1.5 inline-block ring-offset-black transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2"
+              >
+                <Image
+                  src="/images/skytruth-30-30-logo.svg"
+                  alt="SkyTruth 30x30"
+                  width={25}
+                  height={25}
+                />
+              </a>
+            ) : (
+              <Link
+                href={{
+                  pathname: '/',
+                  query: runAsOf ? { 'run-as-of': runAsOf } : '',
+                }}
+                className="-my-1.5 inline-block ring-offset-black transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2"
+              >
+                <Image
+                  src="/images/skytruth-30-30-logo.svg"
+                  alt="SkyTruth 30x30"
+                  width={25}
+                  height={25}
+                />
+              </Link>
+            ))}
         </span>
 
         {/* Mobile hamburger menu */}

--- a/frontend/src/components/header/index.tsx
+++ b/frontend/src/components/header/index.tsx
@@ -137,6 +137,8 @@ const Header: FCWithMessages<HeaderProps> = ({ theme, hideLogo = false }) => {
             (hideInfoPages ? (
               <a
                 href="https://www.skytruth.org/30x30"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="-my-1.5 inline-block ring-offset-black transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2"
               >
                 <Image

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -21,6 +21,7 @@ import Layout, { Content, Sidebar } from '@/layouts/static-page';
 import { fetchTranslations } from '@/lib/i18n';
 import { formatPercentage } from '@/lib/utils/formats';
 import { FCWithMessages } from '@/types';
+import { getFeatureFlags } from '@/types/generated/feature-flag';
 import {
   getGetProtectionCoverageStatsQueryKey,
   getGetProtectionCoverageStatsQueryOptions,
@@ -239,6 +240,32 @@ const Home: FCWithMessages = ({
 Home.messages = ['pages.home', ...Layout.messages, ...Intro.messages, ...LinkCards.messages];
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { 'run-as-of': runAsOf } = context.query;
+
+  // TECH 3447 teardown: remove feature flag check and make this redirect unconditional
+  const featureFlags = await getFeatureFlags({
+    filters: {
+      feature: {
+        $eq: 'hide_info_pages',
+      },
+    },
+    // @ts-ignore
+    'run-as-of': runAsOf,
+    'pagination[limit]': 1,
+  });
+  const shouldRedirect = featureFlags?.[0]?.attributes?.payload;
+
+  if (shouldRedirect) {
+    return {
+      redirect: {
+        destination: `/progress-tracker${runAsOf ? `?run-as-of=${runAsOf}` : ''}`,
+        permanent: false, // TECH 3447: Make true
+      },
+    };
+  }
+
+  // TECH 3447 teardown: remove everything below this line
+
   const queryClient = new QueryClient();
 
   const protectionCoverageStatsQueryParams = {


### PR DESCRIPTION
## What does this PR do?

This PR is in preparation for the new SkyTruth website launch of 5/4. When the website launches the info on the landing page will be included on `skytruth.org/30x30`. This PR updates link in the app logo to go to the new project landing page as opposed to `/`. It also implements a redirect from `/` to `/progress-tracker` as the progress tracker will be the new user facing landing page. This is all gated by a feature flag that will go live on 5/4/2026

## Designs

_Include screenshots / figma links if applicable_

## How was this tested/  how can it be tested?
Locally and in Dev by navigation to `/??run-as-of=2026-05-04T21:32:42.532Z`

## Link relevant Jira tickets

## Checklist before submitting

- [x] Merged or rebased latest code from `main`
- [x] Tested changes on staging before Prod deployment
- [x] Appropriate linters or formatters run
- [x] Documentation, logging, alerts, etc appropriately updated as needed
- [x] [Checked Demo Calendar](https://calendar.google.com/calendar/embed?src=c_650a13af470a46193658bb5cbddf79ecdb4e43bdc838d595937de6ae490704c3%40group.calendar.google.com&ctz=America%2FPhoenix) before deploying