### PR TITLE
Add MPAtlas tileset and data processing

### DIFF
--- a/cloud_functions/data_processing/docker-compose.yml
+++ b/cloud_functions/data_processing/docker-compose.yml
@@ -5,9 +5,12 @@ services:
       context: .
     volumes:
       - ./:/app
+      - ~/.config/gcloud:/root/.config/gcloud:ro
     ports:
       - 3001:8080
     env_file: .env
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: always

--- a/cloud_functions/data_processing/src/core/map_params.py
+++ b/cloud_functions/data_processing/src/core/map_params.py
@@ -44,13 +44,18 @@ TERRESTRIAL_PA_TILESET_FILE = f"maps/terrestrial_pas_{today_formatted}.mbtiles"
 MARINE_PA_TILESET_ID = "marine_pas"
 MARINE_PA_TILESET_NAME = "Marine PAs"
 MARINE_PA_TILESET_FILE = f"maps/marine_pas_{today_formatted}.mbtiles"
-
 WDPA_TOLERANCE = 0.001
 
+# ------------------------
+# MPAtlas_old [Retired]
+# ------------------------
+#MPATLAS_TILESET_ID = "mpaatlas_tiles"
+#MPATLAST_TILESET_NAME = "mpa_atlas"
+#MPATLAS_TILESET_FILE = f"maps/mpa_atlas_{today_formatted}.mbtiles"
 
 # ------------------------
-# MPAtlas
+# MPAtlas_New
 # ------------------------
-MPATLAS_TILESET_ID = "mpaatlas_tiles"
-MPATLAST_TILESET_NAME = "mpa_atlas"
-MPATLAS_TILESET_FILE = f"maps/mpa_atlas_{today_formatted}.mbtiles"
+MPATLAS_TILESET_ID = "mpatlas"
+MPATLAST_TILESET_NAME = "MPATLAS"
+MPATLAS_TILESET_FILE = f"maps/mpatlas_{today_formatted}.mbtiles"

--- a/cloud_functions/data_processing/src/core/map_params.py
+++ b/cloud_functions/data_processing/src/core/map_params.py
@@ -46,3 +46,11 @@ MARINE_PA_TILESET_NAME = "Marine PAs"
 MARINE_PA_TILESET_FILE = f"maps/marine_pas_{today_formatted}.mbtiles"
 
 WDPA_TOLERANCE = 0.001
+
+
+# ------------------------
+# MPAtlas
+# ------------------------
+MPATLAS_TILESET_ID = "mpaatlas_tiles"
+MPATLAST_TILESET_NAME = "mpa_atlas"
+MPATLAS_TILESET_FILE = f"maps/mpa_atlas_{today_formatted}.mbtiles"

--- a/cloud_functions/data_processing/src/core/map_params.py
+++ b/cloud_functions/data_processing/src/core/map_params.py
@@ -47,13 +47,6 @@ MARINE_PA_TILESET_FILE = f"maps/marine_pas_{today_formatted}.mbtiles"
 WDPA_TOLERANCE = 0.001
 
 # ------------------------
-# MPAtlas_old [Retired]
-# ------------------------
-#MPATLAS_TILESET_ID = "mpaatlas_tiles"
-#MPATLAST_TILESET_NAME = "mpa_atlas"
-#MPATLAS_TILESET_FILE = f"maps/mpa_atlas_{today_formatted}.mbtiles"
-
-# ------------------------
 # MPAtlas_New
 # ------------------------
 MPATLAS_TILESET_ID = "mpatlas"

--- a/cloud_functions/data_processing/src/core/retry_params.py
+++ b/cloud_functions/data_processing/src/core/retry_params.py
@@ -22,6 +22,10 @@ METHOD_RETRY_CONFIGS = {
         "delay_seconds": ONE_DAY,
         "max_retries": 7,
     },
+    "update_mpatlas_tileset": {
+        "delay_seconds": ONE_HOUR,
+        "max_retries": 3,
+    },
 }
 
 

--- a/cloud_functions/data_processing/src/methods/publisher.py
+++ b/cloud_functions/data_processing/src/methods/publisher.py
@@ -70,6 +70,7 @@ from src.methods.tileset_processes import (
     create_and_update_country_tileset,
     create_and_update_eez_tileset,
     create_and_update_marine_regions_tileset,
+    create_and_update_mpatlas_tileset,
     create_and_update_protected_area_tileset,
     create_and_update_terrestrial_regions_tileset,
 )
@@ -535,6 +536,11 @@ def dispatch_publisher(
                 tileset_id=map_params.TERRESTRIAL_PA_TILESET_ID,
                 display_name=map_params.TERRESTRIAL_PA_TILESET_NAME,
                 tolerance=map_params.WDPA_TOLERANCE,
+                verbose=verbose,
+            )
+
+        case "create_and_update_mpatlas_tileset":
+            create_and_update_mpatlas_tileset(
                 verbose=verbose,
             )
 

--- a/cloud_functions/data_processing/src/methods/publisher.py
+++ b/cloud_functions/data_processing/src/methods/publisher.py
@@ -399,8 +399,11 @@ def dispatch_publisher(
             step_list = ["update_protection_coverage_stats"]
 
         case "generate_marine_protection_level_stats_table":
-            _ = generate_marine_protection_level_stats_table(verbose=verbose)
-            step_list = ["update_mpaa_protection_level_stats"]
+            updates = generate_marine_protection_level_stats_table(verbose=verbose)
+            if updates:
+                step_list = ["update_mpaa_protection_level_stats"]
+                if env == "production":
+                    step_list.extend(["create_and_update_mpatlas_tileset"])
 
         case "generate_fishing_protection_table":
             _ = generate_fishing_protection_table(verbose=verbose)

--- a/cloud_functions/data_processing/src/methods/publisher.py
+++ b/cloud_functions/data_processing/src/methods/publisher.py
@@ -399,11 +399,10 @@ def dispatch_publisher(
             step_list = ["update_protection_coverage_stats"]
 
         case "generate_marine_protection_level_stats_table":
-            updates = generate_marine_protection_level_stats_table(verbose=verbose)
-            if updates:
-                step_list = ["update_mpaa_protection_level_stats"]
-                if env == "production":
-                    step_list.extend(["create_and_update_mpatlas_tileset"])
+            _ = generate_marine_protection_level_stats_table(verbose=verbose)
+            step_list = ["update_mpaa_protection_level_stats"]
+            if env == "production":
+                step_list.extend(["update_mpatlas_tileset"])
 
         case "generate_fishing_protection_table":
             _ = generate_fishing_protection_table(verbose=verbose)
@@ -542,7 +541,7 @@ def dispatch_publisher(
                 verbose=verbose,
             )
 
-        case "create_and_update_mpatlas_tileset":
+        case "update_mpatlas_tileset":
             create_and_update_mpatlas_tileset(
                 verbose=verbose,
             )

--- a/cloud_functions/data_processing/src/methods/tileset_processes.py
+++ b/cloud_functions/data_processing/src/methods/tileset_processes.py
@@ -72,7 +72,7 @@ def mpatlas_process(gdf: gpd.GeoDataFrame, ctx: dict[str, Any]):
         "geometry",
     ]
 
-    #simplify geometry to match same simplification of Protected Areas
+    # simplify geometry to match same simplification of Protected Areas
     gdf["geometry"] = gdf["geometry"].simplify(TOLERANCES[0])
 
     gdf.drop(columns=list(set(gdf.columns) - set(keep)), inplace=True)

--- a/cloud_functions/data_processing/src/methods/tileset_processes.py
+++ b/cloud_functions/data_processing/src/methods/tileset_processes.py
@@ -27,6 +27,7 @@ from src.core.params import (
     LOCATIONS_TRANSLATED_FILE_NAME,
     REGIONS_FILE_NAME,
     RELATED_COUNTRIES_FILE_NAME,
+    MPATLAS_FILE_NAME,
 )
 from src.core.processors import add_translations
 from src.utils.gcp import read_dataframe, read_json_from_gcs
@@ -34,6 +35,67 @@ from src.utils.logger import Logger
 from src.utils.mbtile_pipeline import TilesetConfig, run_tileset_pipeline
 
 logger = Logger()
+
+def mpatlas_process(gdf: gpd.GeoDataFrame, ctx: dict[str,Any]):
+    gdf = gdf.rename(columns={
+        "designation": "designatio",
+        "establishment_stage": "establishm",
+        "country": "location_i",
+        "mpa_zone_id": "mpa_zone_i", 
+        "protection_mpaguide_level": "protection",
+        "implemented_date" :"year",
+    })
+
+    #Create a new bucketed column based on the protection value, returning only 1. fully or highly or 2. less or unknown
+    gdf["protecti_1"] = gdf["protection"].apply(
+        lambda x: "fully or highly" if x in ["full", "high"] else "less or unknown")
+
+    keep = ["designatio", "establishm", "location_i", "mpa_zone_i", "name", "protection", "protecti_1", "wdpa_id", "year"]
+    gdf.drop(columns=list(set(gdf.columns) - set(keep)), inplace=True)
+
+    return gdf
+
+
+def create_and_update_mpatlas_tileset(
+    bucket: str = BUCKET,
+    source_file: str = MPATLAS_FILE_NAME,
+    #these are placeholders following the naming convention of other tilesets 
+    tileset_file: str = MPATLAS_TILESET_FILE,
+    tileset_id: str = MPATLAS_TILESET_ID, 
+    display_name: str = MPATLAST_TILESET_NAME,
+    verbose: bool = False,
+    *,
+    keep_temp: bool = False,
+):
+
+    try:
+        if verbose:
+            logger.info({"message": f"Creating and updating {display_name} tileset..."})
+
+        cfg = TilesetConfig(
+            bucket=bucket,
+            tileset_blob_name=tileset_file,
+            tileset_id=tileset_id,
+            display_name=display_name,
+            local_geojson_name=f"{tileset_id}.geojson",
+            local_mbtiles_name=f"{tileset_id}.mbtiles",
+            source_file=source_file,
+            verbose=verbose,
+            keep_temp=keep_temp,
+        )
+
+        return run_tileset_pipeline(
+            cfg,
+            process=mpatlas_process,
+        )
+    except Exception as excep:
+        logger.error(
+            {
+                "message": "Error creating and updating MPAtlas tileset",
+                "error": str(excep),
+            }
+        )
+        raise excep
 
 
 def eez_process(gdf: gpd.GeoDataFrame, ctx: dict[str, Any]):

--- a/cloud_functions/data_processing/src/methods/tileset_processes.py
+++ b/cloud_functions/data_processing/src/methods/tileset_processes.py
@@ -77,10 +77,6 @@ def mpatlas_process(gdf: gpd.GeoDataFrame, ctx: dict[str, Any]):
 def create_and_update_mpatlas_tileset(
     bucket: str = BUCKET,
     source_file: str = MPATLAS_FILE_NAME,
-<<<<<<< Updated upstream
-    # these are placeholders following the naming convention of other tilesets
-=======
->>>>>>> Stashed changes
     tileset_file: str = MPATLAS_TILESET_FILE,
     tileset_id: str = MPATLAS_TILESET_ID,
     display_name: str = MPATLAST_TILESET_NAME,

--- a/cloud_functions/data_processing/src/methods/tileset_processes.py
+++ b/cloud_functions/data_processing/src/methods/tileset_processes.py
@@ -31,8 +31,10 @@ from src.core.params import (
     MPATLAS_FILE_NAME,
     REGIONS_FILE_NAME,
     RELATED_COUNTRIES_FILE_NAME,
+    TOLERANCES,
 )
 from src.core.processors import add_translations
+from src.core.retry_params import METHOD_RETRY_CONFIGS, ScheduleRetry
 from src.utils.gcp import read_dataframe, read_json_from_gcs
 from src.utils.logger import Logger
 from src.utils.mbtile_pipeline import TilesetConfig, run_tileset_pipeline
@@ -69,6 +71,10 @@ def mpatlas_process(gdf: gpd.GeoDataFrame, ctx: dict[str, Any]):
         "year",
         "geometry",
     ]
+
+    #simplify geometry to match same simplification of Protected Areas
+    gdf["geometry"] = gdf["geometry"].simplify(TOLERANCES[0])
+
     gdf.drop(columns=list(set(gdf.columns) - set(keep)), inplace=True)
 
     return gdf
@@ -80,6 +86,7 @@ def create_and_update_mpatlas_tileset(
     tileset_file: str = MPATLAS_TILESET_FILE,
     tileset_id: str = MPATLAS_TILESET_ID,
     display_name: str = MPATLAST_TILESET_NAME,
+    method: str = "update_mpatlas_tileset",
     verbose: bool = False,
     *,
     keep_temp: bool = False,
@@ -104,14 +111,21 @@ def create_and_update_mpatlas_tileset(
             cfg,
             process=mpatlas_process,
         )
-    except Exception as excep:
+    except Exception as e:
         logger.error(
             {
-                "message": "Error creating and updating MPAtlas tileset",
-                "error": str(excep),
+                "message": f"Error creating and updating {display_name} tileset",
+                "error": str(e),
             }
         )
-        raise excep
+        retry_cfg = METHOD_RETRY_CONFIGS.get(method)
+        if retry_cfg:
+            raise ScheduleRetry(
+                delay_seconds=retry_cfg["delay_seconds"],
+                max_retries=retry_cfg["max_retries"],
+                message=f"{display_name} tileset update failed: {e}",
+            ) from e
+        raise
 
 
 def eez_process(gdf: gpd.GeoDataFrame, ctx: dict[str, Any]):

--- a/cloud_functions/data_processing/src/methods/tileset_processes.py
+++ b/cloud_functions/data_processing/src/methods/tileset_processes.py
@@ -15,6 +15,9 @@ from src.core.map_params import (
     MARINE_REGIONS_TILESET_FILE,
     MARINE_REGIONS_TILESET_ID,
     MARINE_REGIONS_TILESET_NAME,
+    MPATLAS_TILESET_FILE,
+    MPATLAS_TILESET_ID,
+    MPATLAST_TILESET_NAME,
     TERRESTRIAL_REGIONS_TILESET_FILE,
     TERRESTRIAL_REGIONS_TILESET_ID,
     TERRESTRIAL_REGIONS_TILESET_NAME,
@@ -25,9 +28,9 @@ from src.core.params import (
     EEZ_MULTIPLE_SOV_FILE_NAME,
     GADM_FILE_NAME,
     LOCATIONS_TRANSLATED_FILE_NAME,
+    MPATLAS_FILE_NAME,
     REGIONS_FILE_NAME,
     RELATED_COUNTRIES_FILE_NAME,
-    MPATLAS_FILE_NAME,
 )
 from src.core.processors import add_translations
 from src.utils.gcp import read_dataframe, read_json_from_gcs
@@ -36,21 +39,36 @@ from src.utils.mbtile_pipeline import TilesetConfig, run_tileset_pipeline
 
 logger = Logger()
 
-def mpatlas_process(gdf: gpd.GeoDataFrame, ctx: dict[str,Any]):
-    gdf = gdf.rename(columns={
-        "designation": "designatio",
-        "establishment_stage": "establishm",
-        "country": "location_i",
-        "mpa_zone_id": "mpa_zone_i", 
-        "protection_mpaguide_level": "protection",
-        "implemented_date" :"year",
-    })
 
-    #Create a new bucketed column based on the protection value, returning only 1. fully or highly or 2. less or unknown
+def mpatlas_process(gdf: gpd.GeoDataFrame, ctx: dict[str, Any]):
+    gdf = gdf.rename(
+        columns={
+            "designation": "designatio",
+            "establishment_stage": "establishm",
+            "country": "location_i",
+            "mpa_zone_id": "mpa_zone_i",
+            "protection_mpaguide_level": "protection",
+            "implemented_date": "year",
+        }
+    )
+
+    # Create a new bucketed column based on the protection value, returning only 1. fully or highly or 2. less or unknown
     gdf["protecti_1"] = gdf["protection"].apply(
-        lambda x: "fully or highly" if x in ["full", "high"] else "less or unknown")
+        lambda x: "fully or highly" if x in ["full", "high"] else "less or unknown"
+    )
 
-    keep = ["designatio", "establishm", "location_i", "mpa_zone_i", "name", "protection", "protecti_1", "wdpa_id", "year"]
+    keep = [
+        "designatio",
+        "establishm",
+        "location_i",
+        "mpa_zone_i",
+        "name",
+        "protection",
+        "protecti_1",
+        "wdpa_id",
+        "year",
+        "geometry",
+    ]
     gdf.drop(columns=list(set(gdf.columns) - set(keep)), inplace=True)
 
     return gdf
@@ -59,15 +77,14 @@ def mpatlas_process(gdf: gpd.GeoDataFrame, ctx: dict[str,Any]):
 def create_and_update_mpatlas_tileset(
     bucket: str = BUCKET,
     source_file: str = MPATLAS_FILE_NAME,
-    #these are placeholders following the naming convention of other tilesets 
+    # these are placeholders following the naming convention of other tilesets
     tileset_file: str = MPATLAS_TILESET_FILE,
-    tileset_id: str = MPATLAS_TILESET_ID, 
+    tileset_id: str = MPATLAS_TILESET_ID,
     display_name: str = MPATLAST_TILESET_NAME,
     verbose: bool = False,
     *,
     keep_temp: bool = False,
 ):
-
     try:
         if verbose:
             logger.info({"message": f"Creating and updating {display_name} tileset..."})

--- a/cloud_functions/data_processing/src/methods/tileset_processes.py
+++ b/cloud_functions/data_processing/src/methods/tileset_processes.py
@@ -77,7 +77,10 @@ def mpatlas_process(gdf: gpd.GeoDataFrame, ctx: dict[str, Any]):
 def create_and_update_mpatlas_tileset(
     bucket: str = BUCKET,
     source_file: str = MPATLAS_FILE_NAME,
+<<<<<<< Updated upstream
     # these are placeholders following the naming convention of other tilesets
+=======
+>>>>>>> Stashed changes
     tileset_file: str = MPATLAS_TILESET_FILE,
     tileset_id: str = MPATLAS_TILESET_ID,
     display_name: str = MPATLAST_TILESET_NAME,

--- a/cloud_functions/data_processing/src/utils/mbtile_pipeline.py
+++ b/cloud_functions/data_processing/src/utils/mbtile_pipeline.py
@@ -88,7 +88,7 @@ def run_tileset_pipeline(
         ctx.update(cfg.extra)
 
     try:
-        check_credentials()
+        #  check_credentials()
         if cfg.verbose:
             print(f"Starting {ctx['display_name']} tileset pipeline...")
 
@@ -125,7 +125,7 @@ def run_tileset_pipeline(
 
             if cfg.verbose:
                 print(f"Uploading {ctx['display_name']} tileset to Mapbox...")
-            upload_mapbox(temp_dir, ctx)
+            # upload_mapbox(temp_dir, ctx)
 
             return {
                 "temp_dir": str(temp_dir if cfg.keep_temp else None),

--- a/cloud_functions/data_processing/src/utils/mbtile_pipeline.py
+++ b/cloud_functions/data_processing/src/utils/mbtile_pipeline.py
@@ -88,7 +88,7 @@ def run_tileset_pipeline(
         ctx.update(cfg.extra)
 
     try:
-        check_credentials()
+        # check_credentials()
         if cfg.verbose:
             print(f"Starting {ctx['display_name']} tileset pipeline...")
 
@@ -125,7 +125,7 @@ def run_tileset_pipeline(
 
             if cfg.verbose:
                 print(f"Uploading {ctx['display_name']} tileset to Mapbox...")
-            upload_mapbox(temp_dir, ctx)
+            # upload_mapbox(temp_dir, ctx)
 
             return {
                 "temp_dir": str(temp_dir if cfg.keep_temp else None),

--- a/cloud_functions/data_processing/src/utils/mbtile_pipeline.py
+++ b/cloud_functions/data_processing/src/utils/mbtile_pipeline.py
@@ -88,7 +88,7 @@ def run_tileset_pipeline(
         ctx.update(cfg.extra)
 
     try:
-        #  check_credentials()
+        check_credentials()
         if cfg.verbose:
             print(f"Starting {ctx['display_name']} tileset pipeline...")
 
@@ -125,7 +125,7 @@ def run_tileset_pipeline(
 
             if cfg.verbose:
                 print(f"Uploading {ctx['display_name']} tileset to Mapbox...")
-            # upload_mapbox(temp_dir, ctx)
+            upload_mapbox(temp_dir, ctx)
 
             return {
                 "temp_dir": str(temp_dir if cfg.keep_temp else None),

--- a/cloud_functions/data_processing/src/utils/mbtile_pipeline.py
+++ b/cloud_functions/data_processing/src/utils/mbtile_pipeline.py
@@ -88,7 +88,7 @@ def run_tileset_pipeline(
         ctx.update(cfg.extra)
 
     try:
-        # check_credentials()
+        check_credentials()
         if cfg.verbose:
             print(f"Starting {ctx['display_name']} tileset pipeline...")
 
@@ -125,7 +125,7 @@ def run_tileset_pipeline(
 
             if cfg.verbose:
                 print(f"Uploading {ctx['display_name']} tileset to Mapbox...")
-            # upload_mapbox(temp_dir, ctx)
+            upload_mapbox(temp_dir, ctx)
 
             return {
                 "temp_dir": str(temp_dir if cfg.keep_temp else None),

--- a/cloud_functions/data_processing/tests/methods/test_tileset_processes.py
+++ b/cloud_functions/data_processing/tests/methods/test_tileset_processes.py
@@ -93,6 +93,20 @@ def mock_add_translations(df, translations_df, key_col, code_col):
             "_3.2.geojson",
             tp.protected_area_process,
         ),
+        (
+            "mpatlas",
+            {
+            "bucket": "bkt",
+                "source_file": "mpa.geojson",
+                "tileset_file": "mpa.mbtiles",
+                "tileset_id": "mpa.id",
+                "display_name": "MPAtlas",
+            },
+            "mpa.id.geojson",
+            ".geojson",          # no tolerance suffix since we pass source_file directly
+            tp.mpatlas_process,
+            
+        ),
     ],
 )
 def test_wrappers_call_pipeline_with_expected_config(
@@ -129,6 +143,8 @@ def test_wrappers_call_pipeline_with_expected_config(
         tp.create_and_update_terrestrial_regions_tileset(**kwargs)
     elif which == "protected":
         tp.create_and_update_protected_area_tileset(**kwargs)
+    elif which == "mpatlas":
+        tp.create_and_update_mpatlas_tileset(**kwargs)
     else:
         raise AssertionError("Unknown case")
 
@@ -143,6 +159,35 @@ def test_wrappers_call_pipeline_with_expected_config(
     assert cfg.tileset_blob_name == kwargs["tileset_file"]
     assert cfg.bucket == kwargs["bucket"]
 
+def test_mpatlas_process():
+    gdf = gpd.GeoDataFrame(
+        {
+            "designation": ["MPA", "MPA", "MPA"],
+            "establishment_stage": ["implemented", "implemented", "implemented"],
+            "country": ["ABNJ", "ABNJ", "ABNJ"],
+            "mpa_zone_id": ["1", "2", "3"],
+            "protection_mpaguide_level": ["high", "full", "low"],
+            "name": ["A", "B", "C"],
+            "wdpa_id": ["1", "2", "3"],
+            "year": ["2017", "2018", "2019"],
+        },
+        geometry=gpd.GeoSeries.from_wkt([
+            "POINT (0 0)", "POINT (1 1)", "POINT (2 2)"
+        ]),
+        crs="EPSG:4326",
+    )
+
+    out = tp.mpatlas_process(gdf.copy(), {"verbose": False})
+    expected = {"designatio", "establishm", "location_i", "mpa_zone_i", "name", "protection", "protecti_1", "wdpa_id", "year", "geometry"}
+
+    # "high" and "full" → "fully or highly"
+    assert out.iloc[0]["protecti_1"] == "fully or highly"
+    assert out.iloc[1]["protecti_1"] == "fully or highly"
+
+    # anything else → "less or unknown"
+    assert out.iloc[2]["protecti_1"] == "less or unknown"
+    assert set(out.columns) == expected
+   
 
 def test_eez_process_drops_expected_columns(mock_gdf):
     gdf = mock_gdf.copy()

--- a/cloud_functions/data_processing/tests/methods/test_tileset_processes.py
+++ b/cloud_functions/data_processing/tests/methods/test_tileset_processes.py
@@ -96,16 +96,15 @@ def mock_add_translations(df, translations_df, key_col, code_col):
         (
             "mpatlas",
             {
-            "bucket": "bkt",
+                "bucket": "bkt",
                 "source_file": "mpa.geojson",
                 "tileset_file": "mpa.mbtiles",
                 "tileset_id": "mpa.id",
                 "display_name": "MPAtlas",
             },
             "mpa.id.geojson",
-            ".geojson",          # no tolerance suffix since we pass source_file directly
+            ".geojson",  # no tolerance suffix since we pass source_file directly
             tp.mpatlas_process,
-            
         ),
     ],
 )
@@ -159,6 +158,7 @@ def test_wrappers_call_pipeline_with_expected_config(
     assert cfg.tileset_blob_name == kwargs["tileset_file"]
     assert cfg.bucket == kwargs["bucket"]
 
+
 def test_mpatlas_process():
     gdf = gpd.GeoDataFrame(
         {
@@ -171,14 +171,23 @@ def test_mpatlas_process():
             "wdpa_id": ["1", "2", "3"],
             "year": ["2017", "2018", "2019"],
         },
-        geometry=gpd.GeoSeries.from_wkt([
-            "POINT (0 0)", "POINT (1 1)", "POINT (2 2)"
-        ]),
+        geometry=gpd.GeoSeries.from_wkt(["POINT (0 0)", "POINT (1 1)", "POINT (2 2)"]),
         crs="EPSG:4326",
     )
 
     out = tp.mpatlas_process(gdf.copy(), {"verbose": False})
-    expected = {"designatio", "establishm", "location_i", "mpa_zone_i", "name", "protection", "protecti_1", "wdpa_id", "year", "geometry"}
+    expected = {
+        "designatio",
+        "establishm",
+        "location_i",
+        "mpa_zone_i",
+        "name",
+        "protection",
+        "protecti_1",
+        "wdpa_id",
+        "year",
+        "geometry",
+    }
 
     # "high" and "full" → "fully or highly"
     assert out.iloc[0]["protecti_1"] == "fully or highly"
@@ -187,7 +196,7 @@ def test_mpatlas_process():
     # anything else → "less or unknown"
     assert out.iloc[2]["protecti_1"] == "less or unknown"
     assert set(out.columns) == expected
-   
+
 
 def test_eez_process_drops_expected_columns(mock_gdf):
     gdf = mock_gdf.copy()


### PR DESCRIPTION
updating to add mpatlas functionality

## What does this PR do?

adds mpatlas processing and tileset 


## How was this tested/  how can it be tested?

added tests for mpatlas process  
`===================== test session starts ======================
platform darwin -- Python 3.13.3, pytest-9.0.2, pluggy-1.6.0 -- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3
cachedir: .pytest_cache
rootdir: /Users/aglevy15/skytruth-30x30/cloud_functions/data_processing
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 12 items / 11 deselected / 1 selected                

tests/methods/test_tileset_processes.py::test_mpatlas_process PASSED [100%]
`
reviewed in QGIS with MPAtlas to confirm same map tiles 
<img width="1032" height="1214" alt="image" src="https://github.com/user-attachments/assets/31bcde13-2234-4dfb-8cfd-b1bd8067fe4d" />


## Link relevant Jira tickets

https://skytruth.atlassian.net/browse/TECH-3345

## Checklist before submitting

- [x] Merged or rebased latest code from `main`
- [x] Tested changes on staging before Prod deployment
- [x] Appropriate linters or formatters run - line too long error ignored
- [ ] Documentation, logging, alerts, etc appropriately updated as needed
- [ ] [Checked Demo Calendar](https://calendar.google.com/calendar/embed?src=c_650a13af470a46193658bb5cbddf79ecdb4e43bdc838d595937de6ae490704c3%40group.calendar.google.com&ctz=America%2FPhoenix) before deploying