### PR TITLE
TECH-3497: Archive raw WDPA data to GCS

### DIFF
--- a/cloud_functions/data_processing/src/core/params.py
+++ b/cloud_functions/data_processing/src/core/params.py
@@ -117,8 +117,7 @@ WDPA_URL = (
     "https://d1gam3xoknrgr2.cloudfront.net/current/"
     f"WDPA_WDOECM_{today_formatted}_Public_all_shp.zip"
 )
-WDPA_FILE_NAME = "raw/WDPA_Public.zip"
-ARCHIVE_WDPA_FILE_NAME = f"archive/raw/WDPA_{today_formatted}_Public.zip"
+ARCHIVE_RAW_WDPA_FILE_NAME = f"archive/raw/WDPA_{today_formatted}.zip"
 WDPA_COUNTRY_LEVEL_FILE_NAME = "raw/WDPA_country_level.csv"
 ARCHIVE_WDPA_COUNTRY_LEVEL_FILE_NAME = f"archive/raw/WDPA_{today_formatted}_country_level.csv"
 WDPA_GLOBAL_LEVEL_FILE_NAME = "raw/WDPA_global_level.csv"

--- a/cloud_functions/data_processing/src/core/params.py
+++ b/cloud_functions/data_processing/src/core/params.py
@@ -117,7 +117,7 @@ WDPA_URL = (
     "https://d1gam3xoknrgr2.cloudfront.net/current/"
     f"WDPA_WDOECM_{today_formatted}_Public_all_shp.zip"
 )
-ARCHIVE_RAW_WDPA_FILE_NAME = f"archive/raw/WDPA_{today_formatted}.zip"
+ARCHIVE_RAW_WDPA_FILE_NAME = f"archive/raw/WDPA_{today_formatted}_Public.zip"
 WDPA_COUNTRY_LEVEL_FILE_NAME = "raw/WDPA_country_level.csv"
 ARCHIVE_WDPA_COUNTRY_LEVEL_FILE_NAME = f"archive/raw/WDPA_{today_formatted}_country_level.csv"
 WDPA_GLOBAL_LEVEL_FILE_NAME = "raw/WDPA_global_level.csv"

--- a/cloud_functions/data_processing/src/methods/download_and_process.py
+++ b/cloud_functions/data_processing/src/methods/download_and_process.py
@@ -32,6 +32,7 @@ from src.core.params import (
     ARCHIVE_PROTECTED_SEAS_FILE_NAME,
     ARCHIVE_WDPA_COUNTRY_LEVEL_FILE_NAME,
     ARCHIVE_WDPA_GLOBAL_LEVEL_FILE_NAME,
+    ARCHIVE_RAW_WDPA_FILE_NAME,
     BUCKET,
     MPATLAS_COUNTRY_LEVEL_API_URL,
     MPATLAS_COUNTRY_LEVEL_FILE_NAME,
@@ -64,6 +65,7 @@ from src.utils.gcp import (
     save_file_bucket,
     upload_dataframe,
     upload_gdf,
+    upload_file_to_gcs
 )
 from src.utils.logger import Logger
 from src.utils.resource_handling import (
@@ -271,6 +273,7 @@ def download_and_process_protected_planet_pas(
     terrestrial_pa_file_name: str = WDPA_TERRESTRIAL_FILE_NAME,
     marine_pa_file_name: str = WDPA_MARINE_FILE_NAME,
     meta_file_name: str = WDPA_META_FILE_NAME,
+    archive_wdpa_file_name: str = ARCHIVE_RAW_WDPA_FILE_NAME,
     tolerance: float = TOLERANCES[0],
     verbose: bool = True,
     bucket: str = BUCKET,
@@ -533,6 +536,15 @@ def download_and_process_protected_planet_pas(
         )
 
     show_container_mem("After download")
+
+    # Save to archive in GCS
+    if verbose:
+        logger.info({"message": f"Saving to archive at {archive_wdpa_file_name}"})
+    upload_file_to_gcs(
+        bucket = bucket, 
+        file_name = base_zip_path, 
+        blob_name = archive_wdpa_file_name,
+    )
 
     if verbose:
         logger.info({"message": f"unzipping {base_zip_path}"})


### PR DESCRIPTION
## What does this PR do?
This updates the `download_protected_planet_pas` method to save a copy of the WDPA zip file to an archive in Google Cloud Storage.

In the function `download_and_process_protected_planet_pas`, the file "`https://d1gam3xoknrgr2.cloudfront.net/current/WDPA_WDOECM_{today_formatted}_Public_all_shp.zip`" is downloaded and saved to Google Cloud Storage at `archive/raw/WDPA_{today_formatted}_Public.zip`.

## How was this tested?
This was tested on April 21, 2026 after deploying the branch to staging, and the `archive/raw/WDPA_Apr2026_Public.zip` has been saved to the `dev` Google Cloud Storage bucket.

## Link relevant Jira tickets
https://skytruth.atlassian.net/browse/TECH-3497

## Checklist before submitting

- [ ] Merged or rebased latest code from `main`
- [ ] Tested changes on staging before Prod deployment
- [ ] Appropriate linters or formatters run
- [ ] Documentation, logging, alerts, etc appropriately updated as needed
- [ ] [Checked Demo Calendar](https://calendar.google.com/calendar/embed?src=c_650a13af470a46193658bb5cbddf79ecdb4e43bdc838d595937de6ae490704c3%40group.calendar.google.com&ctz=America%2FPhoenix) before deploying