### PR TITLE
Remove draft publish state from DB tables

### DIFF
--- a/cms/src/api/contact-detail/content-types/contact-detail/schema.json
+++ b/cms/src/api/contact-detail/content-types/contact-detail/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {
     "i18n": {

--- a/cms/src/api/data-tool-ecosystem/content-types/data-tool-ecosystem/schema.json
+++ b/cms/src/api/data-tool-ecosystem/content-types/data-tool-ecosystem/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {
     "i18n": {

--- a/cms/src/api/data-tool-language/content-types/data-tool-language/schema.json
+++ b/cms/src/api/data-tool-language/content-types/data-tool-language/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {
     "i18n": {
@@ -26,12 +26,12 @@
     },
     "slug": {
       "type": "string",
-      "unique": false,
       "pluginOptions": {
         "i18n": {
           "localized": false
         }
-      }
+      },
+      "unique": false
     },
     "data_tool": {
       "type": "relation",

--- a/cms/src/api/data-tool-resource-type/content-types/data-tool-resource-type/schema.json
+++ b/cms/src/api/data-tool-resource-type/content-types/data-tool-resource-type/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {
     "i18n": {
@@ -18,12 +18,12 @@
   "attributes": {
     "name": {
       "type": "string",
-      "unique": false,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "unique": false
     }
   }
 }

--- a/cms/src/api/data-tool/content-types/data-tool/schema.json
+++ b/cms/src/api/data-tool/content-types/data-tool/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {
     "i18n": {
@@ -18,12 +18,12 @@
   "attributes": {
     "name": {
       "type": "string",
-      "required": true,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "required": true
     },
     "description": {
       "type": "text",

--- a/cms/src/api/dataset/content-types/dataset/schema.json
+++ b/cms/src/api/dataset/content-types/dataset/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {
     "i18n": {
@@ -18,13 +18,13 @@
   "attributes": {
     "name": {
       "type": "string",
-      "required": true,
-      "unique": false,
       "pluginOptions": {
         "i18n": {
           "localized": true
         }
-      }
+      },
+      "required": true,
+      "unique": false
     },
     "layers": {
       "type": "relation",
@@ -32,14 +32,14 @@
       "target": "api::layer.layer"
     },
     "slug": {
+      "type": "string",
       "pluginOptions": {
         "i18n": {
           "localized": false
         }
       },
-      "type": "string",
-      "unique": false,
-      "required": true
+      "required": true,
+      "unique": false
     }
   }
 }

--- a/cms/src/api/static-indicator/content-types/static-indicator/schema.json
+++ b/cms/src/api/static-indicator/content-types/static-indicator/schema.json
@@ -8,7 +8,7 @@
     "description": ""
   },
   "options": {
-    "draftAndPublish": true
+    "draftAndPublish": false
   },
   "pluginOptions": {
     "i18n": {

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -439,7 +439,7 @@ export interface ApiContactDetailContactDetail extends Struct.SingleTypeSchema {
     singularName: 'contact-detail';
   };
   options: {
-    draftAndPublish: true;
+    draftAndPublish: false;
   };
   pluginOptions: {
     i18n: {
@@ -603,7 +603,7 @@ export interface ApiDataToolEcosystemDataToolEcosystem
     singularName: 'data-tool-ecosystem';
   };
   options: {
-    draftAndPublish: true;
+    draftAndPublish: false;
   };
   pluginOptions: {
     i18n: {
@@ -642,7 +642,7 @@ export interface ApiDataToolLanguageDataToolLanguage
     singularName: 'data-tool-language';
   };
   options: {
-    draftAndPublish: true;
+    draftAndPublish: false;
   };
   pluginOptions: {
     i18n: {
@@ -691,7 +691,7 @@ export interface ApiDataToolResourceTypeDataToolResourceType
     singularName: 'data-tool-resource-type';
   };
   options: {
-    draftAndPublish: true;
+    draftAndPublish: false;
   };
   pluginOptions: {
     i18n: {
@@ -729,7 +729,7 @@ export interface ApiDataToolDataTool extends Struct.CollectionTypeSchema {
     singularName: 'data-tool';
   };
   options: {
-    draftAndPublish: true;
+    draftAndPublish: false;
   };
   pluginOptions: {
     i18n: {
@@ -798,7 +798,7 @@ export interface ApiDatasetDataset extends Struct.CollectionTypeSchema {
     singularName: 'dataset';
   };
   options: {
-    draftAndPublish: true;
+    draftAndPublish: false;
   };
   pluginOptions: {
     i18n: {
@@ -1678,7 +1678,7 @@ export interface ApiStaticIndicatorStaticIndicator
     singularName: 'static-indicator';
   };
   options: {
-    draftAndPublish: true;
+    draftAndPublish: false;
   };
   pluginOptions: {
     i18n: {

--- a/frontend/src/components/map/types.ts
+++ b/frontend/src/components/map/types.ts
@@ -2,7 +2,7 @@ import type { ViewState, MapProps } from 'react-map-gl';
 
 import { FitBoundsOptions } from 'mapbox-gl';
 
-export interface CustomMapProps extends MapProps {
+export interface CustomMapProps extends Omit<MapProps, 'projection'> {
   id?: string;
   /** A function that returns the map instance */
   children?: React.ReactNode;


### PR DESCRIPTION
## What does this PR do?

This PR removes the possibility of a draft and publish state the DB and API for all fields except Layers. This removes. a manual step for translations every time a field is changed, and given that we aren't making use of draft and publish states this is a ton of unnecessary friction

## Designs

_Include screenshots / figma links if applicable_

## How was this tested/  how can it be tested?

## Link relevant Jira tickets

## Checklist before submitting

- [x] Merged or rebased latest code from `main`
- [x] Tested changes on staging before Prod deployment
- [x] Appropriate linters or formatters run
- [x] Documentation, logging, alerts, etc appropriately updated as needed
- [x] [Checked Demo Calendar](https://calendar.google.com/calendar/embed?src=c_650a13af470a46193658bb5cbddf79ecdb4e43bdc838d595937de6ae490704c3%40group.calendar.google.com&ctz=America%2FPhoenix) before deploying