### PR TITLE
scale up API memory

### DIFF
--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -20,8 +20,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -37,8 +37,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -54,8 +54,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -64,30 +64,6 @@
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::contact-detail.contact-detail",
-      "properties": {
-        "fields": [
-          "name",
-          "address",
-          "phone",
-          "email",
-          "registration"
-        ],
-        "locales": [
-          "en",
-          "es",
-          "fr",
-          "pt",
-          "id",
-          "sw"
-        ]
-      },
-      "conditions": [],
-      "actionParameters": {},
-      "locale": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::contact-detail.contact-detail",
       "properties": {
         "fields": [
@@ -102,8 +78,32 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "locale": null
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::contact-detail.contact-detail",
+      "properties": {
+        "fields": [
+          "name",
+          "address",
+          "phone",
+          "email",
+          "registration"
+        ],
+        "locales": [
+          "en",
+          "es",
+          "fr",
+          "pt",
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -124,8 +124,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -141,8 +141,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -158,8 +158,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -168,28 +168,6 @@
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::data-info.data-info",
-      "properties": {
-        "fields": [
-          "slug",
-          "content",
-          "data_sources"
-        ],
-        "locales": [
-          "en",
-          "es",
-          "fr",
-          "pt",
-          "id",
-          "sw"
-        ]
-      },
-      "conditions": [],
-      "actionParameters": {},
-      "locale": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::data-info.data-info",
       "properties": {
         "fields": [
@@ -202,8 +180,30 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "locale": null
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::data-info.data-info",
+      "properties": {
+        "fields": [
+          "slug",
+          "content",
+          "data_sources"
+        ],
+        "locales": [
+          "en",
+          "es",
+          "fr",
+          "pt",
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -224,8 +224,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -241,8 +241,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -258,8 +258,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -280,8 +280,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -302,8 +302,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -322,8 +322,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -339,8 +339,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -356,8 +356,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -376,8 +376,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -396,8 +396,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -418,8 +418,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -435,8 +435,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -452,8 +452,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -474,8 +474,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -496,8 +496,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -516,8 +516,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -533,8 +533,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -550,8 +550,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -570,8 +570,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -590,8 +590,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -616,8 +616,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -633,8 +633,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -650,8 +650,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -676,8 +676,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -702,8 +702,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -724,8 +724,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -741,8 +741,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -758,8 +758,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -780,8 +780,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -802,8 +802,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -823,8 +823,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -840,8 +840,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -857,8 +857,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -878,8 +878,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -899,8 +899,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1049,8 +1049,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1066,8 +1066,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1083,8 +1083,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1105,8 +1105,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1127,8 +1127,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1216,8 +1216,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1233,8 +1233,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1250,8 +1250,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1272,8 +1272,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1294,8 +1294,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1333,8 +1333,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1350,8 +1350,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1367,8 +1367,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1406,8 +1406,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1445,8 +1445,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1573,8 +1573,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1590,8 +1590,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1607,8 +1607,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1629,8 +1629,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1651,8 +1651,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1673,8 +1673,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1690,8 +1690,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1707,8 +1707,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1729,8 +1729,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1751,8 +1751,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1837,8 +1837,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1854,8 +1854,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1871,8 +1871,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1893,8 +1893,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -1915,8 +1915,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2122,8 +2122,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2139,8 +2139,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2156,8 +2156,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2178,8 +2178,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2200,8 +2200,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2223,8 +2223,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2240,8 +2240,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2257,8 +2257,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2280,8 +2280,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],
@@ -2303,8 +2303,8 @@
           "es",
           "fr",
           "pt",
-          "id",
-          "sw"
+          "sw",
+          "id"
         ]
       },
       "conditions": [],

--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -20,8 +20,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -37,8 +37,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -54,8 +54,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -64,30 +64,6 @@
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::contact-detail.contact-detail",
-      "properties": {
-        "fields": [
-          "name",
-          "address",
-          "phone",
-          "email",
-          "registration"
-        ],
-        "locales": [
-          "en",
-          "es",
-          "fr",
-          "pt",
-          "sw",
-          "id"
-        ]
-      },
-      "conditions": [],
-      "actionParameters": {},
-      "locale": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::contact-detail.contact-detail",
       "properties": {
         "fields": [
@@ -102,8 +78,32 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "locale": null
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::contact-detail.contact-detail",
+      "properties": {
+        "fields": [
+          "name",
+          "address",
+          "phone",
+          "email",
+          "registration"
+        ],
+        "locales": [
+          "en",
+          "es",
+          "fr",
+          "pt",
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -124,8 +124,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -141,8 +141,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -158,8 +158,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -168,28 +168,6 @@
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::data-info.data-info",
-      "properties": {
-        "fields": [
-          "slug",
-          "content",
-          "data_sources"
-        ],
-        "locales": [
-          "en",
-          "es",
-          "fr",
-          "pt",
-          "sw",
-          "id"
-        ]
-      },
-      "conditions": [],
-      "actionParameters": {},
-      "locale": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::data-info.data-info",
       "properties": {
         "fields": [
@@ -202,8 +180,30 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "locale": null
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::data-info.data-info",
+      "properties": {
+        "fields": [
+          "slug",
+          "content",
+          "data_sources"
+        ],
+        "locales": [
+          "en",
+          "es",
+          "fr",
+          "pt",
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -224,8 +224,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -241,8 +241,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -258,8 +258,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -280,8 +280,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -302,8 +302,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -322,8 +322,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -339,8 +339,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -356,8 +356,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -376,8 +376,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -396,8 +396,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -418,8 +418,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -435,8 +435,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -452,8 +452,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -474,8 +474,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -496,8 +496,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -516,8 +516,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -533,8 +533,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -550,8 +550,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -570,8 +570,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -590,8 +590,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -616,8 +616,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -633,8 +633,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -650,8 +650,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -676,8 +676,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -702,8 +702,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -724,8 +724,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -741,8 +741,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -758,8 +758,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -780,8 +780,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -802,8 +802,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -823,8 +823,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -840,8 +840,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -857,8 +857,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -878,8 +878,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -899,8 +899,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1049,8 +1049,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1066,8 +1066,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1083,8 +1083,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1105,8 +1105,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1127,8 +1127,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1216,8 +1216,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1233,8 +1233,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1250,8 +1250,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1272,8 +1272,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1294,8 +1294,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1333,8 +1333,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1350,8 +1350,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1367,8 +1367,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1406,8 +1406,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1445,8 +1445,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1573,8 +1573,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1590,8 +1590,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1607,8 +1607,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1629,8 +1629,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1651,8 +1651,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1673,8 +1673,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1690,8 +1690,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1707,8 +1707,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1729,8 +1729,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1751,8 +1751,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1837,8 +1837,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1854,8 +1854,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1871,8 +1871,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1893,8 +1893,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -1915,8 +1915,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2122,8 +2122,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2139,8 +2139,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2156,8 +2156,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2178,8 +2178,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2200,8 +2200,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2223,8 +2223,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2240,8 +2240,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2257,8 +2257,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2280,8 +2280,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],
@@ -2303,8 +2303,8 @@
           "es",
           "fr",
           "pt",
-          "sw",
-          "id"
+          "id",
+          "sw"
         ]
       },
       "conditions": [],

--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -22,6 +22,7 @@ module "staging" {
   backend_min_scale                                  = 0
   frontend_max_scale                                 = 1
   backend_max_scale                                  = 2
+  backend_available_memory                           = "2Gi"
   dns_zone_name                                      = module.dns.dns_zone_name
   domain                                             = var.domain
   subdomain                                          = var.staging_subdomain
@@ -63,6 +64,7 @@ module "production" {
   backend_min_scale                                  = 0
   frontend_max_scale                                 = 1
   backend_max_scale                                  = 2
+  backend_available_memory                           = "2Gi"
   dns_zone_name                                      = module.dns.dns_zone_name
   domain                                             = var.domain
   subdomain                                          = var.production_subdomain

--- a/infrastructure/base/modules/cloudrun/main.tf
+++ b/infrastructure/base/modules/cloudrun/main.tf
@@ -33,7 +33,7 @@ resource "google_cloud_run_service" "cloud_run" {
 
   template {
     spec {
-      timeout_seconds  = var.timeout_seconds
+      timeout_seconds      = var.timeout_seconds
       service_account_name = google_service_account.service_account.email
 
       containers {
@@ -41,6 +41,12 @@ resource "google_cloud_run_service" "cloud_run" {
 
         ports {
           container_port = var.container_port
+        }
+
+        resources {
+          limits = {
+            memory = var.memory
+          }
         }
       }
     }

--- a/infrastructure/base/modules/cloudrun/main.tf
+++ b/infrastructure/base/modules/cloudrun/main.tf
@@ -45,6 +45,7 @@ resource "google_cloud_run_service" "cloud_run" {
 
         resources {
           limits = {
+            cpu    = var.cpu
             memory = var.memory
           }
         }

--- a/infrastructure/base/modules/cloudrun/variables.tf
+++ b/infrastructure/base/modules/cloudrun/variables.tf
@@ -82,3 +82,9 @@ variable "tag" {
   type        = string
   description = "Tag name to use for docker image tagging and deployment"
 }
+
+variable "memory" {
+  type        = string
+  description = "Memory limit for the container (e.g. \"512Mi\", \"1Gi\")"
+  default     = "512Mi"
+}

--- a/infrastructure/base/modules/cloudrun/variables.tf
+++ b/infrastructure/base/modules/cloudrun/variables.tf
@@ -88,3 +88,9 @@ variable "memory" {
   description = "Memory limit for the container (e.g. \"512Mi\", \"1Gi\")"
   default     = "512Mi"
 }
+
+variable "cpu" {
+  type        = string
+  description = "CPU limit for the container (e.g. \"1000m\", \"2000m\"). Defaults to Cloud Run's standard 1000m to avoid resource drift."
+  default     = "1000m"
+}

--- a/infrastructure/base/modules/cloudrun_job/main.tf
+++ b/infrastructure/base/modules/cloudrun_job/main.tf
@@ -42,7 +42,7 @@ resource "google_cloud_run_v2_job" "default" {
       dynamic "vpc_access" {
         for_each = var.vpc_connector_name == null ? [] : [1]
         content {
-            connector = "projects/${var.project_id}/locations/${var.region}/connectors/${var.vpc_connector_name}"
+          connector = "projects/${var.project_id}/locations/${var.region}/connectors/${var.vpc_connector_name}"
         }
       }
 
@@ -88,7 +88,7 @@ resource "google_cloud_run_v2_job" "default" {
       client,
       client_version,
       labels,
-      template[0].labels,  
+      template[0].labels,
     ]
   }
 

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -58,6 +58,7 @@ module "backend_cloudrun" {
   max_scale             = var.backend_max_scale
   tag                   = var.environment
   timeout_seconds       = 1800
+  memory                = var.backend_available_memory
   use_hello_world_image = var.use_hello_world_image
 }
 
@@ -331,17 +332,17 @@ resource "google_storage_bucket_iam_member" "pmtiles_public_read" {
 
 locals {
   data_processing_env = {
-    BUCKET              = google_storage_bucket.data_bucket.name
-    DATABASE_HOST       = module.database.database_host
-    DATABASE_NAME       = module.database.database_name
-    DATABASE_USERNAME   = module.database.database_user
-    MAPBOX_USER         = var.mapbox_user
-    PROJECT             = var.gcp_project_id
-    STRAPI_API_URL      = local.api_lb_url
-    STRAPI_USERNAME     = var.backend_write_user
-    LOCATION            = var.gcp_region
-    ENVIRONMENT         = var.environment
-    PMTILES_BUCKET      = google_storage_bucket.pmtiles_bucket.name
+    BUCKET            = google_storage_bucket.data_bucket.name
+    DATABASE_HOST     = module.database.database_host
+    DATABASE_NAME     = module.database.database_name
+    DATABASE_USERNAME = module.database.database_user
+    MAPBOX_USER       = var.mapbox_user
+    PROJECT           = var.gcp_project_id
+    STRAPI_API_URL    = local.api_lb_url
+    STRAPI_USERNAME   = var.backend_write_user
+    LOCATION          = var.gcp_region
+    ENVIRONMENT       = var.environment
+    PMTILES_BUCKET    = google_storage_bucket.pmtiles_bucket.name
   }
 
   data_processing_secrets = [{
@@ -349,30 +350,30 @@ locals {
     project_id = var.gcp_project_id
     secret     = "protected-planet-api-key"
     version    = "latest"
-  },
-  {
-    key        = "STRAPI_PASSWORD"
-    project_id = var.gcp_project_id
-    secret     = "${var.project_name}_strapi_write_user_password"
-    version    = "latest"
-  },
-  {
-    key        = "MAPBOX_TOKEN"
-    project_id = var.gcp_project_id
-    secret     = "mapbox_token"
-    version    = "latest"
-  },
-  {
-    key        = "DATABASE_PASSWORD"
-    project_id = var.gcp_project_id
-    secret     = module.postgres_application_user_password.secret_name
-    version    = module.postgres_application_user_password.latest_version
-  },
-  {
-    key        = "SLACK_ALERTS_WEBHOOK"
-    project_id = var.gcp_project_id
-    secret     = "gcp-slack-alerts-webhook"
-    version    = "latest"
+    },
+    {
+      key        = "STRAPI_PASSWORD"
+      project_id = var.gcp_project_id
+      secret     = "${var.project_name}_strapi_write_user_password"
+      version    = "latest"
+    },
+    {
+      key        = "MAPBOX_TOKEN"
+      project_id = var.gcp_project_id
+      secret     = "mapbox_token"
+      version    = "latest"
+    },
+    {
+      key        = "DATABASE_PASSWORD"
+      project_id = var.gcp_project_id
+      secret     = module.postgres_application_user_password.secret_name
+      version    = module.postgres_application_user_password.latest_version
+    },
+    {
+      key        = "SLACK_ALERTS_WEBHOOK"
+      project_id = var.gcp_project_id
+      secret     = "gcp-slack-alerts-webhook"
+      version    = "latest"
   }]
 }
 
@@ -398,17 +399,17 @@ module "data_pipes_cloud_function" {
 
 
 module "data_pipes_cloudrun_jobs" {
-  source                           = "../cloudrun_job"
-  project_id                       = var.gcp_project_id
-  region                           = var.gcp_region
-  job_name                         = "${var.project_name}-data-cloudrun-job"
-  env                              = local.data_processing_env
-  secrets                          = local.data_processing_secrets
-  image                            = var.cloudrun_jobs_image
-  timeout_seconds                  = var.cloudrun_jobs_timeout_seconds
-  cpu                              = var.cloudrun_jobs_available_cpu
-  memory                           = var.cloudrun_jobs_available_memory
-  vpc_connector_name               = module.network.vpc_access_connector_name
+  source             = "../cloudrun_job"
+  project_id         = var.gcp_project_id
+  region             = var.gcp_region
+  job_name           = "${var.project_name}-data-cloudrun-job"
+  env                = local.data_processing_env
+  secrets            = local.data_processing_secrets
+  image              = var.cloudrun_jobs_image
+  timeout_seconds    = var.cloudrun_jobs_timeout_seconds
+  cpu                = var.cloudrun_jobs_available_cpu
+  memory             = var.cloudrun_jobs_available_memory
+  vpc_connector_name = module.network.vpc_access_connector_name
 }
 
 
@@ -469,7 +470,7 @@ resource "google_cloud_run_v2_job_iam_member" "caller_job_can_run_target_job" {
   project  = var.gcp_project_id
   location = var.gcp_region
 
-  name     = module.data_pipes_cloudrun_jobs.job_name
+  name = module.data_pipes_cloudrun_jobs.job_name
 
   role   = "roles/run.developer"
   member = "serviceAccount:${module.data_pipes_cloudrun_jobs.job_service_account_email}"
@@ -478,7 +479,7 @@ resource "google_cloud_run_v2_job_iam_member" "caller_job_can_run_target_job" {
 variable "cloud_tasks_roles" {
   description = "List of roles to grant to the Data Pipes Service Account"
   type        = list(string)
-  default     = [
+  default = [
     "roles/iam.serviceAccountTokenCreator",
     "roles/iam.serviceAccountUser",
     "roles/cloudtasks.enqueuer"
@@ -496,7 +497,7 @@ resource "google_cloudfunctions2_function_iam_member" "cloudtasks_invoker" {
   cloud_function = module.data_pipes_cloud_function.function_name
   role           = "roles/cloudfunctions.invoker"
   member         = "serviceAccount:${google_service_account.cloudtasks_invoker.email}"
-  depends_on = [google_service_account.cloudtasks_invoker]
+  depends_on     = [google_service_account.cloudtasks_invoker]
 }
 
 # Allow the Data Pipes Cloud Function SA to run the Cloud Run Job
@@ -512,17 +513,17 @@ resource "google_cloud_run_v2_job_iam_member" "data_function_can_run_job" {
 module "monthly_job_queue" {
   source = "../cloudtasks"
 
-  queue_name  = "${var.project_name}-monthly-data-pipes-jobs"
-  location    = var.gcp_region
+  queue_name = "${var.project_name}-monthly-data-pipes-jobs"
+  location   = var.gcp_region
 
-  target_url = module.data_pipes_cloud_function.function_uri
+  target_url                    = module.data_pipes_cloud_function.function_uri
   invoker_service_account_email = google_service_account.cloudtasks_invoker.email
 
   max_concurrent_dispatches = 1
   max_dispatches_per_second = 1
 
   # Just try one time - retries are handled in handler
-  max_attempts       = 1
+  max_attempts = 1
 
   enable_dlq = false
 }
@@ -533,21 +534,21 @@ resource "google_service_account" "scheduler_invoker" {
 }
 
 module "data_pipes_scheduler" {
-  source                   = "../cloud_scheduler"
-  name                     = "${var.project_name}-trigger-data-pipes-method"
-  schedule                 = "0 8 1 * *"
-  target_url               = module.data_pipes_cloud_function.function_uri
-  invoker_service_account  = google_service_account.scheduler_invoker.email
+  source                  = "../cloud_scheduler"
+  name                    = "${var.project_name}-trigger-data-pipes-method"
+  schedule                = "0 8 1 * *"
+  target_url              = module.data_pipes_cloud_function.function_uri
+  invoker_service_account = google_service_account.scheduler_invoker.email
   headers = {
     "Content-Type" = "application/json"
   }
   body = jsonencode({
-    METHOD              = "publisher",
-    TRIGGER_NEXT        = true,
-    QUEUE_NAME          = module.monthly_job_queue.queue_name,
-    JOB_NAME            = module.data_pipes_cloudrun_jobs.job_name,
-    TARGET_URL          = module.data_pipes_cloud_function.function_uri,
-    INVOKER_SA          = google_service_account.cloudtasks_invoker.email
+    METHOD       = "publisher",
+    TRIGGER_NEXT = true,
+    QUEUE_NAME   = module.monthly_job_queue.queue_name,
+    JOB_NAME     = module.data_pipes_cloudrun_jobs.job_name,
+    TARGET_URL   = module.data_pipes_cloud_function.function_uri,
+    INVOKER_SA   = google_service_account.cloudtasks_invoker.email
   })
 }
 

--- a/infrastructure/base/modules/env/variables.tf
+++ b/infrastructure/base/modules/env/variables.tf
@@ -71,6 +71,12 @@ variable "backend_max_scale" {
   default     = 5
 }
 
+variable "backend_available_memory" {
+  type        = string
+  description = "Memory limit for the backend Cloud Run container (e.g. \"512Mi\", \"1Gi\")"
+  default     = "512Mi"
+}
+
 variable "cors_origin" {
   type        = string
   description = "Origin for CORS config"


### PR DESCRIPTION
## What does this PR do?
Increases the memory allocation of the Strapi API from 512 Mb to 2Gb.

After the upgrade to Strapi V5 we are running very close to 100% and have seen some deploy failures because of running out of Memory

Memory consumption since V5 deploy
<img width="1287" height="409" alt="Screenshot 2026-05-13 at 12 13 12 PM" src="https://github.com/user-attachments/assets/84295468-630d-4b39-8789-4f0ba87e0a61" />

## Designs

_Include screenshots / figma links if applicable_

## How was this tested/  how can it be tested?

Rolled out in dev

## Link relevant Jira tickets

## Checklist before submitting

- [x] Merged or rebased latest code from `main`
- [x] Tested changes on staging before Prod deployment
- [x] Appropriate linters or formatters run
- [x] Documentation, logging, alerts, etc appropriately updated as needed
- [x] [Checked Demo Calendar](https://calendar.google.com/calendar/embed?src=c_650a13af470a46193658bb5cbddf79ecdb4e43bdc838d595937de6ae490704c3%40group.calendar.google.com&ctz=America%2FPhoenix) before deploying