### PR TITLE
Add ID and SW translations for EEZs

### DIFF
--- a/cloud_functions/data_processing/src/core/processors.py
+++ b/cloud_functions/data_processing/src/core/processors.py
@@ -654,7 +654,7 @@ def add_translations(
     gdf = gdf.copy()
 
     gdf = gdf.merge(
-        translations[[translation_field, "name", "name_es", "name_fr", "name_pt"]],
+        translations[[translation_field, "name", "name_es", "name_fr", "name_pt", "name_sw", "name_id"]],
         left_on=gdf_field,
         right_on=translation_field,
         how="left",

--- a/cloud_functions/data_processing/src/core/processors.py
+++ b/cloud_functions/data_processing/src/core/processors.py
@@ -654,7 +654,9 @@ def add_translations(
     gdf = gdf.copy()
 
     gdf = gdf.merge(
-        translations[[translation_field, "name", "name_es", "name_fr", "name_pt", "name_sw", "name_id"]],
+        translations[
+            [translation_field, "name", "name_es", "name_fr", "name_pt", "name_sw", "name_id"]
+        ],
         left_on=gdf_field,
         right_on=translation_field,
         how="left",

--- a/cloud_functions/data_processing/src/methods/static_processes.py
+++ b/cloud_functions/data_processing/src/methods/static_processes.py
@@ -123,7 +123,9 @@ def process_gadm_geoms(
     hong_kong.loc[:, "GID_0"] = "HKG"
     hong_kong = hong_kong[["GID_0", "COUNTRY", "geometry"]]
     # Remove Hong Kong from China in the countries layer
-    countries.loc[countries["GID_0"] == "CHN", "geometry"] = countries.loc[countries["GID_0"] == "CHN", "geometry"].difference(hong_kong.geometry.iloc[0])
+    countries.loc[countries["GID_0"] == "CHN", "geometry"] = countries.loc[
+        countries["GID_0"] == "CHN", "geometry"
+    ].difference(hong_kong.geometry.iloc[0])
 
     abnj = {"GID_0": "ABNJ", "COUNTRY": "Areas Beyond National Jurisdiction", "geometry": None}
     abnj = gpd.GeoDataFrame([abnj], crs=countries.crs)

--- a/cloud_functions/data_processing/tests/methods/test_static_processes.py
+++ b/cloud_functions/data_processing/tests/methods/test_static_processes.py
@@ -128,6 +128,8 @@ def mock_eez_translations():
             "name_es": ["Zona A", "Zona B", "Alta Mar"],
             "name_fr": ["Zone A", "Zone B", "Haute mer"],
             "name_pt": ["Área A", "Área B", "Alto-mar"],
+            "name_id": ["Área A", "Área B", "Laut Lepas"],
+            "name_sw": ["Área A", "Área B", "Bahari Kuu"],
         }
     )
 
@@ -470,6 +472,8 @@ def test_proccess_eez_multiple_sovs_happy_path(
         "name_es",
         "name_fr",
         "name_pt",
+        "name_id",
+        "name_sw"
     }
 
     assert expect_cols.issubset(out.columns)

--- a/cloud_functions/data_processing/tests/methods/test_static_processes.py
+++ b/cloud_functions/data_processing/tests/methods/test_static_processes.py
@@ -473,7 +473,7 @@ def test_proccess_eez_multiple_sovs_happy_path(
         "name_fr",
         "name_pt",
         "name_id",
-        "name_sw"
+        "name_sw",
     }
 
     assert expect_cols.issubset(out.columns)

--- a/frontend/src/containers/map/content/map/popup/constants.ts
+++ b/frontend/src/containers/map/content/map/popup/constants.ts
@@ -15,7 +15,7 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
       fr: 'name_fr',
       pt: 'name_pt',
       id: 'name_id',
-      sw: 'name_sw'
+      sw: 'name_sw',
     },
   },
   'marine-regions-source': {

--- a/frontend/src/containers/map/content/map/popup/constants.ts
+++ b/frontend/src/containers/map/content/map/popup/constants.ts
@@ -14,6 +14,8 @@ export const POPUP_PROPERTIES_BY_SOURCE = {
       es: 'name_es',
       fr: 'name_fr',
       pt: 'name_pt',
+      id: 'name_id',
+      sw: 'name_sw'
     },
   },
   'marine-regions-source': {


### PR DESCRIPTION
## What does this PR do?

This PR adds support for Bahasa and Kiswahili translations to the EEZ map tiles and associated reading logic.

Note: this comes with an update the EEZ translation file in the dev and prod data processing buckets

## Designs

_Include screenshots / figma links if applicable_

## How was this tested/  how can it be tested?

Tested locally and in dev

## Link relevant Jira tickets

[TECH-3538](https://skytruth.atlassian.net/browse/TECH-3538)

## Checklist before submitting

- [x] Merged or rebased latest code from `main`
- [x] Tested changes on staging before Prod deployment
- [x] Appropriate linters or formatters run
- [x] Documentation, logging, alerts, etc appropriately updated as needed
- [x] [Checked Demo Calendar](https://calendar.google.com/calendar/embed?src=c_650a13af470a46193658bb5cbddf79ecdb4e43bdc838d595937de6ae490704c3%40group.calendar.google.com&ctz=America%2FPhoenix) before deploying