### PR TITLE
Fix: Preserve legend order when adding new layers

### DIFF
--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -16,10 +16,10 @@
           "registration"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -33,10 +33,10 @@
       "subject": "api::contact-detail.contact-detail",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -50,10 +50,10 @@
       "subject": "api::contact-detail.contact-detail",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -64,30 +64,6 @@
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::contact-detail.contact-detail",
-      "properties": {
-        "fields": [
-          "name",
-          "address",
-          "phone",
-          "email",
-          "registration"
-        ],
-        "locales": [
-          "en",
-          "es",
-          "fr",
-          "pt",
-          "id",
-          "sw"
-        ]
-      },
-      "conditions": [],
-      "actionParameters": {},
-      "locale": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::contact-detail.contact-detail",
       "properties": {
         "fields": [
@@ -98,10 +74,34 @@
           "registration"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
+          "id",
+          "sw"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "locale": null
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::contact-detail.contact-detail",
+      "properties": {
+        "fields": [
+          "name",
+          "address",
+          "phone",
+          "email",
+          "registration"
+        ],
+        "locales": [
+          "es",
+          "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -120,10 +120,10 @@
           "data_sources"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -137,10 +137,10 @@
       "subject": "api::data-info.data-info",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -154,10 +154,10 @@
       "subject": "api::data-info.data-info",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -168,28 +168,6 @@
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::data-info.data-info",
-      "properties": {
-        "fields": [
-          "slug",
-          "content",
-          "data_sources"
-        ],
-        "locales": [
-          "en",
-          "es",
-          "fr",
-          "pt",
-          "id",
-          "sw"
-        ]
-      },
-      "conditions": [],
-      "actionParameters": {},
-      "locale": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::data-info.data-info",
       "properties": {
         "fields": [
@@ -198,10 +176,32 @@
           "data_sources"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
+          "id",
+          "sw"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "locale": null
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::data-info.data-info",
+      "properties": {
+        "fields": [
+          "slug",
+          "content",
+          "data_sources"
+        ],
+        "locales": [
+          "es",
+          "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -220,10 +220,10 @@
           "url"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -237,10 +237,10 @@
       "subject": "api::data-source.data-source",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -254,10 +254,10 @@
       "subject": "api::data-source.data-source",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -276,10 +276,10 @@
           "url"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -298,10 +298,10 @@
           "url"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -318,10 +318,10 @@
           "name"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -335,10 +335,10 @@
       "subject": "api::data-tool-ecosystem.data-tool-ecosystem",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -352,10 +352,10 @@
       "subject": "api::data-tool-ecosystem.data-tool-ecosystem",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -372,10 +372,10 @@
           "name"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -392,10 +392,10 @@
           "name"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -414,10 +414,10 @@
           "data_tool"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -431,10 +431,10 @@
       "subject": "api::data-tool-language.data-tool-language",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -448,10 +448,10 @@
       "subject": "api::data-tool-language.data-tool-language",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -470,10 +470,10 @@
           "data_tool"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -492,10 +492,10 @@
           "data_tool"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -512,10 +512,10 @@
           "name"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -529,10 +529,10 @@
       "subject": "api::data-tool-resource-type.data-tool-resource-type",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -546,10 +546,10 @@
       "subject": "api::data-tool-resource-type.data-tool-resource-type",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -566,10 +566,10 @@
           "name"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -586,10 +586,10 @@
           "name"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -612,10 +612,10 @@
           "data_tool_ecosystems"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -629,10 +629,10 @@
       "subject": "api::data-tool.data-tool",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -646,10 +646,10 @@
       "subject": "api::data-tool.data-tool",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -672,10 +672,10 @@
           "data_tool_ecosystems"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -698,10 +698,10 @@
           "data_tool_ecosystems"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -720,10 +720,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -737,10 +737,10 @@
       "subject": "api::dataset.dataset",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -754,10 +754,10 @@
       "subject": "api::dataset.dataset",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -776,10 +776,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -798,10 +798,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -819,10 +819,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -836,10 +836,10 @@
       "subject": "api::environment.environment",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -853,10 +853,10 @@
       "subject": "api::environment.environment",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -874,10 +874,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -895,10 +895,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1045,10 +1045,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1062,10 +1062,10 @@
       "subject": "api::fishing-protection-level.fishing-protection-level",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1079,10 +1079,10 @@
       "subject": "api::fishing-protection-level.fishing-protection-level",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1101,10 +1101,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1123,10 +1123,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1212,10 +1212,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1229,10 +1229,10 @@
       "subject": "api::habitat.habitat",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1246,10 +1246,10 @@
       "subject": "api::habitat.habitat",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1268,10 +1268,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1290,10 +1290,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1329,10 +1329,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1346,10 +1346,10 @@
       "subject": "api::layer.layer",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1363,10 +1363,10 @@
       "subject": "api::layer.layer",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1402,10 +1402,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1441,10 +1441,10 @@
           "slug"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1569,10 +1569,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1586,10 +1586,10 @@
       "subject": "api::mpa-iucn-category.mpa-iucn-category",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1603,10 +1603,10 @@
       "subject": "api::mpa-iucn-category.mpa-iucn-category",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1625,10 +1625,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1647,10 +1647,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1669,10 +1669,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1686,10 +1686,10 @@
       "subject": "api::mpaa-establishment-stage.mpaa-establishment-stage",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1703,10 +1703,10 @@
       "subject": "api::mpaa-establishment-stage.mpaa-establishment-stage",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1725,10 +1725,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1747,10 +1747,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1833,10 +1833,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1850,10 +1850,10 @@
       "subject": "api::mpaa-protection-level.mpaa-protection-level",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1867,10 +1867,10 @@
       "subject": "api::mpaa-protection-level.mpaa-protection-level",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1889,10 +1889,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -1911,10 +1911,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2118,10 +2118,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2135,10 +2135,10 @@
       "subject": "api::protection-status.protection-status",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2152,10 +2152,10 @@
       "subject": "api::protection-status.protection-status",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2174,10 +2174,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2196,10 +2196,10 @@
           "info"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2219,10 +2219,10 @@
           "description"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2236,10 +2236,10 @@
       "subject": "api::static-indicator.static-indicator",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2253,10 +2253,10 @@
       "subject": "api::static-indicator.static-indicator",
       "properties": {
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2276,10 +2276,10 @@
           "description"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]
@@ -2299,10 +2299,10 @@
           "description"
         ],
         "locales": [
-          "en",
           "es",
-          "fr",
           "pt",
+          "en",
+          "fr",
           "id",
           "sw"
         ]

--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -16,10 +16,10 @@
           "registration"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -33,10 +33,10 @@
       "subject": "api::contact-detail.contact-detail",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -50,10 +50,10 @@
       "subject": "api::contact-detail.contact-detail",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -64,30 +64,6 @@
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::contact-detail.contact-detail",
-      "properties": {
-        "fields": [
-          "name",
-          "address",
-          "phone",
-          "email",
-          "registration"
-        ],
-        "locales": [
-          "es",
-          "pt",
-          "en",
-          "fr",
-          "id",
-          "sw"
-        ]
-      },
-      "conditions": [],
-      "actionParameters": {},
-      "locale": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::contact-detail.contact-detail",
       "properties": {
         "fields": [
@@ -98,10 +74,34 @@
           "registration"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
+          "id",
+          "sw"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "locale": null
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::contact-detail.contact-detail",
+      "properties": {
+        "fields": [
+          "name",
+          "address",
+          "phone",
+          "email",
+          "registration"
+        ],
+        "locales": [
+          "en",
+          "es",
+          "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -120,10 +120,10 @@
           "data_sources"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -137,10 +137,10 @@
       "subject": "api::data-info.data-info",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -154,10 +154,10 @@
       "subject": "api::data-info.data-info",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -168,28 +168,6 @@
     },
     {
       "action": "plugin::content-manager.explorer.read",
-      "subject": "api::data-info.data-info",
-      "properties": {
-        "fields": [
-          "slug",
-          "content",
-          "data_sources"
-        ],
-        "locales": [
-          "es",
-          "pt",
-          "en",
-          "fr",
-          "id",
-          "sw"
-        ]
-      },
-      "conditions": [],
-      "actionParameters": {},
-      "locale": null
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "subject": "api::data-info.data-info",
       "properties": {
         "fields": [
@@ -198,10 +176,32 @@
           "data_sources"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
+          "id",
+          "sw"
+        ]
+      },
+      "conditions": [],
+      "actionParameters": {},
+      "locale": null
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "subject": "api::data-info.data-info",
+      "properties": {
+        "fields": [
+          "slug",
+          "content",
+          "data_sources"
+        ],
+        "locales": [
+          "en",
+          "es",
+          "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -220,10 +220,10 @@
           "url"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -237,10 +237,10 @@
       "subject": "api::data-source.data-source",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -254,10 +254,10 @@
       "subject": "api::data-source.data-source",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -276,10 +276,10 @@
           "url"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -298,10 +298,10 @@
           "url"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -318,10 +318,10 @@
           "name"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -335,10 +335,10 @@
       "subject": "api::data-tool-ecosystem.data-tool-ecosystem",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -352,10 +352,10 @@
       "subject": "api::data-tool-ecosystem.data-tool-ecosystem",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -372,10 +372,10 @@
           "name"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -392,10 +392,10 @@
           "name"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -414,10 +414,10 @@
           "data_tool"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -431,10 +431,10 @@
       "subject": "api::data-tool-language.data-tool-language",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -448,10 +448,10 @@
       "subject": "api::data-tool-language.data-tool-language",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -470,10 +470,10 @@
           "data_tool"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -492,10 +492,10 @@
           "data_tool"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -512,10 +512,10 @@
           "name"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -529,10 +529,10 @@
       "subject": "api::data-tool-resource-type.data-tool-resource-type",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -546,10 +546,10 @@
       "subject": "api::data-tool-resource-type.data-tool-resource-type",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -566,10 +566,10 @@
           "name"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -586,10 +586,10 @@
           "name"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -612,10 +612,10 @@
           "data_tool_ecosystems"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -629,10 +629,10 @@
       "subject": "api::data-tool.data-tool",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -646,10 +646,10 @@
       "subject": "api::data-tool.data-tool",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -672,10 +672,10 @@
           "data_tool_ecosystems"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -698,10 +698,10 @@
           "data_tool_ecosystems"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -720,10 +720,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -737,10 +737,10 @@
       "subject": "api::dataset.dataset",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -754,10 +754,10 @@
       "subject": "api::dataset.dataset",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -776,10 +776,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -798,10 +798,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -819,10 +819,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -836,10 +836,10 @@
       "subject": "api::environment.environment",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -853,10 +853,10 @@
       "subject": "api::environment.environment",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -874,10 +874,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -895,10 +895,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1045,10 +1045,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1062,10 +1062,10 @@
       "subject": "api::fishing-protection-level.fishing-protection-level",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1079,10 +1079,10 @@
       "subject": "api::fishing-protection-level.fishing-protection-level",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1101,10 +1101,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1123,10 +1123,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1212,10 +1212,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1229,10 +1229,10 @@
       "subject": "api::habitat.habitat",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1246,10 +1246,10 @@
       "subject": "api::habitat.habitat",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1268,10 +1268,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1290,10 +1290,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1329,10 +1329,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1346,10 +1346,10 @@
       "subject": "api::layer.layer",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1363,10 +1363,10 @@
       "subject": "api::layer.layer",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1402,10 +1402,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1441,10 +1441,10 @@
           "slug"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1569,10 +1569,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1586,10 +1586,10 @@
       "subject": "api::mpa-iucn-category.mpa-iucn-category",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1603,10 +1603,10 @@
       "subject": "api::mpa-iucn-category.mpa-iucn-category",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1625,10 +1625,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1647,10 +1647,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1669,10 +1669,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1686,10 +1686,10 @@
       "subject": "api::mpaa-establishment-stage.mpaa-establishment-stage",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1703,10 +1703,10 @@
       "subject": "api::mpaa-establishment-stage.mpaa-establishment-stage",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1725,10 +1725,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1747,10 +1747,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1833,10 +1833,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1850,10 +1850,10 @@
       "subject": "api::mpaa-protection-level.mpaa-protection-level",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1867,10 +1867,10 @@
       "subject": "api::mpaa-protection-level.mpaa-protection-level",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1889,10 +1889,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -1911,10 +1911,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2118,10 +2118,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2135,10 +2135,10 @@
       "subject": "api::protection-status.protection-status",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2152,10 +2152,10 @@
       "subject": "api::protection-status.protection-status",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2174,10 +2174,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2196,10 +2196,10 @@
           "info"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2219,10 +2219,10 @@
           "description"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2236,10 +2236,10 @@
       "subject": "api::static-indicator.static-indicator",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2253,10 +2253,10 @@
       "subject": "api::static-indicator.static-indicator",
       "properties": {
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2276,10 +2276,10 @@
           "description"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]
@@ -2299,10 +2299,10 @@
           "description"
         ],
         "locales": [
-          "es",
-          "pt",
           "en",
+          "es",
           "fr",
+          "pt",
           "id",
           "sw"
         ]

--- a/frontend/src/containers/map/sidebar/layers-panel/custom-layers/custom-layer-group.tsx
+++ b/frontend/src/containers/map/sidebar/layers-panel/custom-layers/custom-layer-group.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/components/analytics/heap';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
-  allActiveLayersAtom,
   bboxLocationAtom,
   customLayersAtom,
   drawStateAtom,
@@ -56,7 +55,6 @@ const CustomLayerGroup: FCWithMessages<CustomLayerGroupProps> = ({
   const persistActionError = persistActionKey ? t(persistActionKey) : null;
 
   const [customLayers, setCustomLayers] = useAtom(customLayersAtom);
-  const [allActiveLayers] = useAtom(allActiveLayersAtom);
   const [modellingCustomLayerId, setModellingCustomLayerId] = useAtom(modellingCustomLayerIdAtom);
   const setDrawState = useSetAtom(drawStateAtom);
   const setModellingState = useSetAtom(modellingAtom);
@@ -69,23 +67,14 @@ const CustomLayerGroup: FCWithMessages<CustomLayerGroupProps> = ({
   const onToggleLayer = useCallback(
     (toggled: CustomLayer, checked: boolean) => {
       const updatedLayers = { ...customLayers };
-      let updatedActiveLayers = [...allActiveLayers];
       updatedLayers[toggled.id].isActive = checked;
-
-      if (checked) {
-        updatedActiveLayers.unshift(toggled.id);
-      } else {
-        updatedActiveLayers = updatedActiveLayers.filter((id) => id !== toggled.id);
-      }
-
       setCustomLayers(updatedLayers);
-
       layerToggleEngaged({
         layerId: 'custom',
         active: checked,
       });
     },
-    [allActiveLayers, customLayers, setCustomLayers]
+    [customLayers, setCustomLayers]
   );
 
   const onDeleteLayer = useCallback(

--- a/frontend/src/hooks/use-sync-all-layers.ts
+++ b/frontend/src/hooks/use-sync-all-layers.ts
@@ -66,8 +66,7 @@ const useSyncAllLayers = (type: MapTypes) => {
         (layer) => customLayers[layer].isActive
       );
 
-      // If only the order changed (no new layers), preserve the user-set order and
-      // skip the resorting below, which would reset custom layers above predefined
+      // If only the order changed (no new layers), skip
       const allTargetLayers = new Set([...activeLayers, ...activeCustomLayers]);
       if (
         allActiveLayersRef.current.length === allTargetLayers.size &&
@@ -75,31 +74,21 @@ const useSyncAllLayers = (type: MapTypes) => {
       )
         return;
 
-      const activeCustomLayersSet = new Set(activeCustomLayers);
-      const activePredefinedLayersSet = new Set(activeLayers);
+      // Define existing layers with order preserved
+      const preservedLayers = allActiveLayersRef.current.filter((layer) =>
+        allTargetLayers.has(layer)
+      );
+      const preservedLayersSet = new Set(preservedLayers);
 
-      const preservedCustomLayers = allActiveLayersRef.current.filter((layer) =>
-        activeCustomLayersSet.has(layer)
-      );
-      const preservedCustomLayersSet = new Set(preservedCustomLayers);
-      const newCustomLayers = activeCustomLayers.filter(
-        (layer) => !preservedCustomLayersSet.has(layer)
-      );
+      // Define new layers
+      const newCustomLayers = activeCustomLayers.filter((layer) => !preservedLayersSet.has(layer));
+      const newPredefinedLayers = activeLayers.filter((layer) => !preservedLayersSet.has(layer));
 
-      const preservedPredefinedLayers = allActiveLayersRef.current.filter((layer) =>
-        activePredefinedLayersSet.has(layer)
-      );
-      const preservedPredefinedLayersSet = new Set(preservedPredefinedLayers);
-      const newPredefinedLayers = activeLayers.filter(
-        (layer) => !preservedPredefinedLayersSet.has(layer)
-      );
-
-      // Set layers to have order: new custom, existing custom, new predefined, existing predefined
+      // Set order with new layers at the top, followed by existing layers
       currentActiveLayers = [
         ...newCustomLayers,
-        ...preservedCustomLayers,
         ...newPredefinedLayers,
-        ...preservedPredefinedLayers,
+        ...preservedLayers,
       ];
     }
 

--- a/frontend/src/hooks/use-sync-all-layers.ts
+++ b/frontend/src/hooks/use-sync-all-layers.ts
@@ -85,11 +85,7 @@ const useSyncAllLayers = (type: MapTypes) => {
       const newPredefinedLayers = activeLayers.filter((layer) => !preservedLayersSet.has(layer));
 
       // Set order with new layers at the top, followed by existing layers
-      currentActiveLayers = [
-        ...newCustomLayers,
-        ...newPredefinedLayers,
-        ...preservedLayers,
-      ];
+      currentActiveLayers = [...newCustomLayers, ...newPredefinedLayers, ...preservedLayers];
     }
 
     setAllActiveLayers(currentActiveLayers);

--- a/frontend/src/hooks/use-sync-all-layers.ts
+++ b/frontend/src/hooks/use-sync-all-layers.ts
@@ -4,17 +4,20 @@ import { useAtom } from 'jotai';
 
 import { useSyncMapLayers } from '@/containers/map/content/map/sync-settings';
 import { allActiveLayersAtom, customLayersAtom } from '@/containers/map/store';
+import { useSyncMapContentSettings } from '@/containers/map/sync-settings';
 import useCustomLayersIndexedDB from '@/hooks/use-custom-layers-indexed-db';
 import { MapTypes } from '@/types/map';
 
 /**
- * This hook coordinates active layers between query params, state, and indexedDB. It also
- * picks up when the map swithces between progress tracker and conservation
- * builder and sets the allActiveLayers atom accordingly -> PT uses only predefined map layers
- * which are indicated in the query paramters, CB uses predefined layers and custom layers which
- * can be in the browsers indexedDB and/or in application state
- * @param type Which maptype is rendered - progress tracker or conservation builder
- *
+ * This hook coordinates active layers between query params, state, and indexedDB.
+ * It also picks up when the map switches between Progress Tracker (PT)
+ * and Conservation Builder (CB) and sets the allActiveLayers atom accordingly.
+ * - PT uses only predefined map layers which are indicated in the query parameters.
+ * - CB uses predefined layers and custom layers which can be in the browser's
+ *   indexedDB and/or in application state.
+ * On environment switch (tab change), a ref-based signal ensures custom layers stay
+ * at the top of the legend order.
+ * @param type Which map type is rendered: Progress Tracker or Conservation Builder
  */
 const useSyncAllLayers = (type: MapTypes) => {
   const [activeLayers] = useSyncMapLayers();
@@ -22,12 +25,23 @@ const useSyncAllLayers = (type: MapTypes) => {
   const [allActiveLayers, setAllActiveLayers] = useAtom(allActiveLayersAtom);
   const [customLayers, setCustomLayers] = useAtom(customLayersAtom);
   const { savedLayers, hasLoadedSavedLayers } = useCustomLayersIndexedDB();
+  const [{ tab }] = useSyncMapContentSettings();
 
   const allActiveLayersRef = useRef(allActiveLayers);
+  const environmentSwitchedRef = useRef(false);
+  const previousTabRef = useRef(tab);
 
   useEffect(() => {
     allActiveLayersRef.current = allActiveLayers;
   }, [allActiveLayers]);
+
+  // Track when the environment (tab) changes
+  useEffect(() => {
+    if (previousTabRef.current !== tab) {
+      environmentSwitchedRef.current = true;
+      previousTabRef.current = tab;
+    }
+  }, [tab]);
 
   // Add layers that have been saved to browser into state
   useEffect(() => {
@@ -54,41 +68,44 @@ const useSyncAllLayers = (type: MapTypes) => {
     });
   }, [type, hasLoadedSavedLayers, savedLayers, setCustomLayers]);
 
-  // keep allActiveLayers synchronized and stable in order while reacting to
-  // predefined/custom layer activation changes. This is mostly helpful when switching
-  // between conservation builder and progress tracker and needing to sync the different
-  // sources of which layers are active
+  // Keep allActiveLayers synchronized whenever the active layer set
+  // (custom or predefined) changes. Newly-added layers appear at the
+  // top of the legend. When switching environments, custom layers are
+  // always first followed by predefined layers.
   useEffect(() => {
-    let currentActiveLayers = [...activeLayers];
-
-    if (type === MapTypes.ConservationBuilder) {
+    if (type === MapTypes.ProgressTracker) {
+      setAllActiveLayers([...activeLayers]);
+    } else if (type === MapTypes.ConservationBuilder) {
       const activeCustomLayers = Object.keys(customLayers).filter(
         (layer) => customLayers[layer].isActive
       );
 
-      // If only the order changed (no new layers), skip
-      const allTargetLayers = new Set([...activeLayers, ...activeCustomLayers]);
+      const allTargetLayers = new Set([...activeCustomLayers, ...activeLayers]);
+
+      // Skip if only the order changed (no new layers)
       if (
         allActiveLayersRef.current.length === allTargetLayers.size &&
         allActiveLayersRef.current.every((l) => allTargetLayers.has(l))
       )
         return;
 
-      // Define existing layers with order preserved
+      // Layers still active from the previous order
       const preservedLayers = allActiveLayersRef.current.filter((layer) =>
         allTargetLayers.has(layer)
       );
       const preservedLayersSet = new Set(preservedLayers);
 
-      // Define new layers
-      const newCustomLayers = activeCustomLayers.filter((layer) => !preservedLayersSet.has(layer));
-      const newPredefinedLayers = activeLayers.filter((layer) => !preservedLayersSet.has(layer));
+      // Layers newly active
+      const newLayers = [...allTargetLayers].filter((layer) => !preservedLayersSet.has(layer));
 
-      // Set order with new layers at the top, followed by existing layers
-      currentActiveLayers = [...newCustomLayers, ...newPredefinedLayers, ...preservedLayers];
+      // If the environment has switched, custom layers move to the top
+      if (environmentSwitchedRef.current) {
+        environmentSwitchedRef.current = false;
+        setAllActiveLayers([...preservedLayers, ...newLayers]);
+      } else {
+        setAllActiveLayers([...newLayers, ...preservedLayers]);
+      }
     }
-
-    setAllActiveLayers(currentActiveLayers);
   }, [type, setAllActiveLayers, activeLayers, customLayers, allActiveLayersRef]);
 };
 


### PR DESCRIPTION
## What does this PR do?
Previously, if you rearrange the layers and then add a predefined layer on Conservation Builder, all the custom layers are moved back to the top. This PR ensures that the legend maintains its order when new layers are added.

## How was this tested
Deployed to staging, tested on Google Chrome and Microsoft Edge

## Checklist before submitting
- [x] Merged or rebased latest code from `main`
- [x] Tested changes on staging before Prod deployment
- [x] Appropriate linters or formatters run
- [x] Documentation, logging, alerts, etc appropriately updated as needed
- [x] [Checked Demo Calendar](https://calendar.google.com/calendar/embed?src=c_650a13af470a46193658bb5cbddf79ecdb4e43bdc838d595937de6ae490704c3%40group.calendar.google.com&ctz=America%2FPhoenix) before deploying