### PR TITLE
Update alerting infra

### DIFF
--- a/infrastructure/base/alerts.tf
+++ b/infrastructure/base/alerts.tf
@@ -1,0 +1,56 @@
+# Shared notification channels attached to all monitoring alert policies
+
+resource "google_monitoring_notification_channel" "alert_email" {
+  display_name = "30x30 Alerts email"
+  type         = "email"
+  labels = {
+    email_address = var.alert_email
+  }
+}
+
+data "google_monitoring_notification_channel" "slack_alerts" {
+  type = "slack"
+  labels = {
+    channel_name = "#30x30-alerts"
+  }
+}
+
+locals {
+  notification_channel_ids = [
+    google_monitoring_notification_channel.alert_email.id,
+    data.google_monitoring_notification_channel.slack_alerts.id,
+  ]
+}
+
+# Cloud Scheduler logs an ERROR entry for every failed job attempt; a single
+# project-wide policy covers the schedulers of both environments.
+resource "google_monitoring_alert_policy" "scheduler_failures" {
+  display_name = "Cloud Scheduler job failure"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Cloud Scheduler job attempt failed"
+
+    condition_matched_log {
+      filter = "resource.type=\"cloud_scheduler_job\" AND severity>=ERROR"
+
+      label_extractors = {
+        environment = "REGEXP_EXTRACT(resource.labels.job_id, \"^(${var.staging_project_name}|${var.production_project_name})\")"
+        job_id      = "EXTRACT(resource.labels.job_id)"
+      }
+    }
+  }
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s"
+    }
+    auto_close = "1800s"
+  }
+
+  documentation {
+    content = "Cloud Scheduler job $${log.extracted_label.job_id} failed in environment $${log.extracted_label.environment}. Check its logs in Cloud Logging for the failed attempt."
+  }
+
+  notification_channels = local.notification_channel_ids
+}

--- a/infrastructure/base/main.tf
+++ b/infrastructure/base/main.tf
@@ -46,7 +46,7 @@ module "staging" {
   cloudrun_jobs_max_instance_request_concurrency     = 10
   cloudrun_jobs_image                                = local.cloudrun_jobs_image
   mapbox_user                                        = "skytruth"
-  uptime_alert_email                                 = var.uptime_alert_email
+  notification_channel_ids                           = local.notification_channel_ids
   environment                                        = "staging"
   database_name                                      = "strapi"
   database_user                                      = "strapi"
@@ -88,7 +88,7 @@ module "production" {
   cloudrun_jobs_max_instance_request_concurrency     = 10
   cloudrun_jobs_image                                = local.cloudrun_jobs_image
   mapbox_user                                        = "skytruth"
-  uptime_alert_email                                 = var.uptime_alert_email
+  notification_channel_ids                           = local.notification_channel_ids
   environment                                        = "production"
   database_name                                      = "strapi"
   database_user                                      = "strapi"

--- a/infrastructure/base/modules/env/main.tf
+++ b/infrastructure/base/modules/env/main.tf
@@ -86,19 +86,19 @@ module "bastion" {
 }
 
 module "client_uptime_check" {
-  source     = "../uptime-check"
-  name       = "${var.project_name} Client"
-  host       = element(split("/", module.frontend_cloudrun.cloudrun_service_url), 2)
-  email      = var.uptime_alert_email
-  project_id = var.gcp_project_id
+  source                = "../uptime-check"
+  name                  = "${var.project_name} Client"
+  host                  = element(split("/", module.frontend_cloudrun.cloudrun_service_url), 2)
+  notification_channels = var.notification_channel_ids
+  project_id            = var.gcp_project_id
 }
 
 module "cms_uptime_check" {
-  source     = "../uptime-check"
-  name       = "${var.project_name} CMS"
-  host       = element(split("/", module.backend_cloudrun.cloudrun_service_url), 2)
-  email      = var.uptime_alert_email
-  project_id = var.gcp_project_id
+  source                = "../uptime-check"
+  name                  = "${var.project_name} CMS"
+  host                  = element(split("/", module.backend_cloudrun.cloudrun_service_url), 2)
+  notification_channels = var.notification_channel_ids
+  project_id            = var.gcp_project_id
 }
 
 module "error_reporting" {

--- a/infrastructure/base/modules/env/variables.tf
+++ b/infrastructure/base/modules/env/variables.tf
@@ -88,9 +88,9 @@ variable "mapbox_user" {
   description = "Service account username for mapbox"
 }
 
-variable "uptime_alert_email" {
-  type        = string
-  description = "Email address to which uptime alerts should be sent"
+variable "notification_channel_ids" {
+  type        = list(string)
+  description = "Notification channel IDs to attach to monitoring alert policies"
 }
 
 variable "environment" {

--- a/infrastructure/base/modules/uptime-check/main.tf
+++ b/infrastructure/base/modules/uptime-check/main.tf
@@ -37,15 +37,5 @@ resource "google_monitoring_alert_policy" "alert_policy" {
     }
   }
 
-  notification_channels = [
-    google_monitoring_notification_channel.email.id
-  ]
-}
-
-resource "google_monitoring_notification_channel" "email" {
-  display_name = "${var.name} Alert email"
-  type         = "email"
-  labels = {
-    email_address = var.email
-  }
+  notification_channels = var.notification_channels
 }

--- a/infrastructure/base/modules/uptime-check/variables.tf
+++ b/infrastructure/base/modules/uptime-check/variables.tf
@@ -21,6 +21,7 @@ variable "period" {
   default = "300s"
 }
 
-variable "email" {
-  type = string
+variable "notification_channels" {
+  type        = list(string)
+  description = "Notification channel IDs to attach to the alert policy"
 }

--- a/infrastructure/base/variables.tf
+++ b/infrastructure/base/variables.tf
@@ -51,7 +51,7 @@ variable "production_subdomain" {
   description = "Subdomain for the production environment"
 }
 
-variable "uptime_alert_email" {
+variable "alert_email" {
   type        = string
-  description = "Email address to which uptime alerts should be sent"
+  description = "Email address to which monitoring alerts should be sent"
 }

--- a/infrastructure/base/vars/terraform.tfvars
+++ b/infrastructure/base/vars/terraform.tfvars
@@ -12,4 +12,4 @@ domain               = "skytruth.org"
 staging_subdomain    = "30x30-dev"
 production_subdomain = "30x30"
 
-uptime_alert_email = "agnieszka.figiel@vizzuality.com"
+alert_email = "tech@skytruth.org"


### PR DESCRIPTION
## What does this PR do?
Updates GCP alerting.

Currently we only have default GCP alerting for uptime checks for the frontend and backend cloud run services and when those fail they email one of the vizzuality contractors that we no longer work with. 

This PR updates that policy to email `tech@gmail.org` - chosen because it's individual employee agnostic - and it posts to `#30x30-alerts` in slack. The latter matches all the bespoke alerting we've added.

## Designs

_Include screenshots / figma links if applicable_

## How was this tested/  how can it be tested?

## Link relevant Jira tickets

## Checklist before submitting

- [x] Merged or rebased latest code from `main`
- [x] Tested changes on staging before Prod deployment
- [x] Appropriate linters or formatters run
- [x] Documentation, logging, alerts, etc appropriately updated as needed
- [x] [Checked Demo Calendar](https://calendar.google.com/calendar/embed?src=c_650a13af470a46193658bb5cbddf79ecdb4e43bdc838d595937de6ae490704c3%40group.calendar.google.com&ctz=America%2FPhoenix) before deploying